### PR TITLE
Enabling mdtest in the main script with easy params

### DIFF
--- a/daos_server_verbs.yml
+++ b/daos_server_verbs.yml
@@ -44,8 +44,6 @@ servers:
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
   - OFI_DOMAIN=mlx5_0
-  # Disable caching
-  - FI_MR_CACHE_MAX_COUNT=0
 
   # Storage definitions
 

--- a/env_daos
+++ b/env_daos
@@ -21,8 +21,7 @@ CPATH=${daosdeps}/pmix/include:${daosdeps}/spdk/include:$CPATH
 export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
 export OFI_INTERFACE=ib0
 export OFI_DOMAIN=mlx5_0
-# Disable Caching
-export FI_MR_CACHE_MAX_COUNT=0
+
 #deps
 ARGOBOTS=${daosdeps}/argobots
 CART=${daosdeps}/cart
@@ -67,10 +66,6 @@ export FI_SOCKETS_MAX_CONN_RETRY PSM2_MULTI_EP FI_PSM2_NAME_SERVER CRT_CTX_SHARE
 export ABT_ENV_MAX_NUM_XSTREAMS ABT_MAX_NUM_XSTREAMS
 export DAOS_PATH OMPI_PATH
 export MPI_LIB=""
-
-#To run in Singleton Mode
-export DAOS_SINGLETON_CLI=1
-export CRT_ATTACH_INFO_PATH=/$LOCATION/install/tmp/
 
 # To run DMG command manually(For daos_agent)
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent

--- a/main.sh
+++ b/main.sh
@@ -211,10 +211,11 @@ run_cart_test(){
 run_mdtest(){
     echo -e "\nCMD: Starting MDTEST...\n"
     for i in "${IOR_PROC_PER_CLIENT[@]}"; do
+	no_of_ps=$(($DAOS_CLIENTS * $i))
 	echo
-        cmd="orterun --timeout 600 $PSM2_CLIENT_PARAM -np $i --map-by node
+        cmd="orterun --timeout 600 $PSM2_CLIENT_PARAM $VERBS_CLIENT_PARAM -np $no_of_ps --map-by node
         --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist mdtest -a DFS  --dfs.destroy --dfs.pool $POOL_UUID 
-        --dfs.cont $(uuidgen) --dfs.svcl $POOL_SVC -n 1000 -z  0/20  -d /"
+        --dfs.cont $(uuidgen) --dfs.svcl $POOL_SVC -n 500  -u -L --dfs.oclass S1 -N 1 -P -d /"
         echo $cmd
 	echo
         eval $cmd
@@ -257,12 +258,11 @@ for test in "$@"; do
 	    echo "SELF_TEST is temporarily disabled - DAOS-3838"
             ;;
         MDTEST)
-            #start_server
-            #start_agent
-	    #create_pool
-            #run_mdtest
-            #killall_proc $test
-	    echo "MDTEST is temporarily disabled - Will be enabled in DAOS-3680/3682"
+            start_server
+            start_agent
+	    create_pool
+            run_mdtest
+            killall_proc $test
             ;;  
         *)
             echo "Unknow test: Please use IOR DAOS_TEST SELF_TEST or MDTEST"

--- a/main.sh
+++ b/main.sh
@@ -260,7 +260,7 @@ for test in "$@"; do
         MDTEST)
             start_server
             start_agent
-	    create_pool
+            create_pool
             run_mdtest
             killall_proc $test
             ;;  


### PR DESCRIPTION
Correcting run_mdtest() to use total ranks as num procs * total clients.
Removing caching env from client and server env files as it was only.
needed due to a bug in cart but after it was updated this is not needed
anymore explicitly.
Removing singleton env variables from client env as it is deprecated.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>