### PR TITLE
Update default value for crt_timeout in daos_server.yml

### DIFF
--- a/daos_server.yml
+++ b/daos_server.yml
@@ -6,17 +6,16 @@ name: daos_server
 nr_hugepages: 4096
 port: 10001
 provider: ofi+verbs;ofi_rxm
+crt_timeout: 300
+crt_ctx_share_addr: 0
 servers:
 - env_vars:
   - ABT_ENV_MAX_NUM_XSTREAMS=100
   - ABT_MAX_NUM_XSTREAMS=100
   - DAOS_MD_CAP=1024
-  - CRT_CTX_SHARE_ADDR=0
-  - CRT_TIMEOUT=30
   - FI_SOCKETS_MAX_CONN_RETRY=1
   - FI_SOCKETS_CONN_TIMEOUT=2000
   - DD_MASK=mgmt,io,md,epc,rebuild
-  - CRT_TIMEOUT=120
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
   - OFI_DOMAIN=mlx5_0


### PR DESCRIPTION
Set crt_timeout to 5min to have enough time to create bigger pool

Signed-off-by: Sylvia Oi Yee Chan <sylvia.oi.yee.chan@intel.com>