### PR TITLE
DAOS-4810 Client & Server Scalability graph for IOR easy with replica…

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,4 +3,5 @@
 rm -rf /dev/shm/*
 rm -rf /tmp/daos*log
 
-mv Log/$SLURM_JOB_ID $LOGS/log_$1
+NUM_SERVERS=$(printf "%03d" $1)
+mv Log/$SLURM_JOB_ID $LOGS/log-S$NUM_SERVERS-$SLURM_JOB_ID

--- a/daos_server.yml
+++ b/daos_server.yml
@@ -1,6 +1,6 @@
 access_points: ['replace_this_server:10001']
 control_log_file: /tmp/daos_control.log
-control_log_mask: DEBUG
+control_log_mask: ERROR 
 helper_log_file: /tmp/daos_admin.log
 name: daos_server
 nr_hugepages: 4096
@@ -19,11 +19,12 @@ servers:
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
   - OFI_DOMAIN=mlx5_0
+  - FI_UNIVERSE_SIZE=16000
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0
   log_file: /tmp/daos_server.log
-  log_mask: ERR
+  log_mask: ERR 
   nr_xs_helpers: 1
   scm_class: ram
   scm_mount: /dev/shm

--- a/openmpi_gen_hostlist.sh
+++ b/openmpi_gen_hostlist.sh
@@ -3,7 +3,9 @@
 N_SERVERS=$1
 N_CLIENTS=$2
 
+srun -n $SLURM_JOB_NUM_NODES hostname > Log/$SLURM_JOB_ID/all_hostlist
 srun -n $SLURM_JOB_NUM_NODES hostname > Log/$SLURM_JOB_ID/daos_all_hostlist
 sed -i "/$(hostname)/d" Log/$SLURM_JOB_ID/daos_all_hostlist
-cat Log/$SLURM_JOB_ID/daos_all_hostlist | tail -$N_SERVERS > Log/$SLURM_JOB_ID/daos_server_hostlist
+cat Log/$SLURM_JOB_ID/daos_all_hostlist | tail -$N_SERVERS > Log/$SLURM_JOB_ID/server_hostlist
+sed 's/$/ slots=1/' Log/$SLURM_JOB_ID/server_hostlist > Log/$SLURM_JOB_ID/daos_server_hostlist
 cat Log/$SLURM_JOB_ID/daos_all_hostlist | head -$N_CLIENTS > Log/$SLURM_JOB_ID/daos_client_hostlist

--- a/testlist.sh
+++ b/testlist.sh
@@ -1,20 +1,172 @@
 #!/bin/sh
 
+# This is the wrapper script to launch scale tests.
+
+declare -a test_array
+declare -A IOR_suite
+declare -A MDT_suite
+
+# Run all three test suites when no argument is given, else the specific test(s) given as arguments
+if [ $# -eq 0 ] ; then
+    test_array=(IOR MDT SELF_TEST)
+else 
+    test_array=("$@")  
+fi
+echo Tests to run are ${test_array[*]}
+
+# IOR test suite
+# Format:[<test name>]="min_servers max_servers num_targets num_ranks replication_type stonewall_timeout run/no_run"
+IOR_suite=( [16Clnt_IOReasy_SX]="1 256 16 32 SX 300 YES" [16Clnt_IORhard_SX]="1 256 16 32 SX 300 YES"
+            [16Clnt_IOReasy_2GX]="2 256 16 32 RP_2GX 300 NO" [16Clnt_IORhard_2GX]="2 256 16 32 RP_2GX 300 NO"
+            [16Clnt_IOReasy_3GX]="4 256 16 32 RP_3GX 300 NO" [16Clnt_IORhard_3GX]="4 256 16 32 RP_3GX 300 NO"
+            [1Sto4C_IOReasy_SX]="1 256 16 32 SX 60 NO" [1Sto4C_IORhard_SX]="1 256 16 32 SX 60 NO" 
+            [1Sto4C_IOReasy_2GX]="2 256 16 32 RP_2GX 60 NO" [1Sto4C_IORhard_2GX]="2 256 16 32 RP_2GX 60 NO"
+            [1Sto4C_IOReasy_3GX]="4 256 16 32 RP_3GX 60 NO" [1Sto4C_IORhard_3GX]="4 256 16 32 RP_3GX 60 NO" )
+
+# MDT test suite
+# Format:[<test name>]="min_servers max_servers num_targets num_ranks replication_type stonewall_timeout run/no_run"
+MDT_suite=( [16Clnt_MDTeasy_SX]="1 256 16 32 SX 300 NO" [16Clnt_MDThard_SX]="1 256 16 32 SX 300 NO"
+            [16Clnt_MDTeasy_2GX]="2 256 16 32 RP_2GX 300 NO" [16Clnt_MDThard_2GX]="2 256 16 32 RP_2GX 300 NO"
+            [16Clnt_MDTeasy_3GX]="4 256 16 32 RP_3GX 300 NO" [16Clnt_MDThard_3GX]="4 256 16 32 RP_3GX 300 NO"
+            [1Sto4C_MDTeasy_SX]="1 256 16 32 SX 60 NO" [1Sto4C_MDThard_SX]="1 256 16 32 SX 60 NO"
+            [1Sto4C_MDTeasy_2GX]="2 256 16 32 RP_2GX 60 NO" [1Sto4C_MDThard_2GX]="2 256 16 32 RP_2GX 60 NO"
+            [1Sto4C_MDTeasy_3GX]="4 256 16 32 RP_3GX 60 NO" [1Sto4C_MDThard_3GX]="4 256 16 32 RP_3GX 60 NO" )
+
+# Set the needed PATH and LD_LIBRARY_PATH
 export PATH=/opt/apps/xalt/xalt/bin:/opt/apps/intel19/python3/3.7.0/bin:/opt/apps/cmake/3.16.1/bin:/opt/apps/autotools/1.2/bin:/opt/apps/git/2.24.1/bin:/opt/intel/compilers_and_libraries_2019.5.281/linux/bin/intel64:/opt/apps/gcc/8.3.0/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:/usr/bin:/opt/ibutils/bin:/opt/ddn/ime/bin:/opt/dell/srvadmin/bin:.
 export LD_LIBRARY_PATH=/opt/apps/intel19/python3/3.7.0/lib:/opt/intel/debugger_2019/libipt/intel64/lib:/opt/intel/compilers_and_libraries_2019.5.281/linux/daal/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64_lin/gcc4.7:/opt/intel/compilers_and_libraries_2019.5.281/linux/mkl/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/apps/gcc/8.3.0/lib64:/opt/apps/gcc/8.3.0/lib:/usr/lib64/:/usr/lib64/
 
-DAOS_DIR="<path_to_daos>"
-DST_DIR="<path_to_daos_scaled_testing>"
-RES_DIR="<path_to_result_dir>"
-JOBNAME="<sbatch_jobname>"
-TIMEOUT="<sbatch_timeout>" #<hh:mm:ss>
-EMAIL="<email>" #<first.last@intel.com>
+# Define the location od daos, sacled testing, results. Extract the build identity as work week identity
+DAOS_DIR="/work/06758/arunar/frontera/BUILDS/20WW33.3+eccd948/daos"
+DST_DIR="/work/06758/arunar/frontera/TESTS/daos_scaled_testing"
+RES_DIR="/work/06758/arunar/frontera/WEEKLY_RESULTS"
+sub_str=${DAOS_DIR%/*}
+if [[ -L "$sub_str" ]] ; then
+    dir_str=`ls -la $dir_str | awk '{print $(NF)}'`
+else
+    dir_str=${sub_str##*/}
+fi
+BLD_DIR=${dir_str:0:8}
+
+# Adjust the TIMEOUT tomaximum expected run time for any test
+JOBNAME="scaletest"
+TIMEOUT="2:00:00" #<hh:mm:ss>
+EMAIL="aruna.ramanan@intel.com" #<first.last@intel.com>
 
 SBPARAMS="-J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL"
 
 export DAOS_DIR
 pushd $DST_DIR
 
+
+# For each test config in the suite run the IOR tests doubling the number of servers each time from min to max servers
+run_IOR () {
+for  element in "${!IOR_suite[@]}"; do 
+
+    export TESTCASE=$element
+    export LOGS=$RES_DIR/$BLD_DIR/$TESTCASE
+    echo $LOGS
+    mkdir -p $LOGS
+
+    # Extract the test caregory and IOR test type. 
+    IFS='_' ; read -ra tcase <<<"$element" 
+    test_type=${tcase[0]}
+    ior_type=${tcase[1]}
+
+    # Extract test config parameters
+    config_str=${IOR_suite[$element]}
+    IFS=' ' ; read -ra config <<<"$config_str" 
+    min_servers=${config[0]}
+    max_servers=${config[1]}
+    targets=${config[2]}
+    ranks=${config[3]}
+    rep_type=${config[4]}
+    sw_timeout=${config[5]}
+    to_run=${config[6]}
+
+    # If a test category is to be run, calculate the number of nodes and cores based on the test type
+    # Set the desired partition to run in
+    if [ "$to_run" = YES ] ; then
+        servers=$min_servers
+        while [ "$servers" -le "$max_servers" ] ; do
+            if [ "$test_type" = "16Clnt" ] ; then
+                num_nodes=$(( $servers+17 ))
+                num_cores=$(( $num_nodes*56 ))
+                clients=16
+            else
+                num_nodes=$(( 1+5*$servers ))
+                num_cores=$(( $num_nodes*56 ))
+                clients=$(( 4*$servers ))
+            fi
+            if [ "$num_nodes" -le 512 ] ; then
+                partition="normal"
+            else
+                partition="large"
+            fi
+            echo Running $ior_type with nodes=$num_nodes cores=$num_cores under partition $partition
+            sbatch $SBPARAMS -N $num_nodes  -n $num_cores -p $partition tests.sh $ior_type $servers $clients $targets $ranks $rep_type $sw_timeout
+            servers=$(( 2*$servers ))
+        done
+    fi
+done
+}
+
+# For each test config in the suite run the mdtest tests doubling the number of servers each time from min to max servers
+run_MDT () {
+for  element in "${!MDT_suite[@]}"; do 
+
+    export TESTCASE=$element
+    export LOGS=$RES_DIR/$BLD_DIR/$TESTCASE
+    echo $LOGS
+    mkdir -p $LOGS
+
+    # Extract the test caregory and IOR test type. 
+    IFS='_' ; read -ra tcase <<<"$element" 
+    test_type=${tcase[0]}
+    mdt_type=${tcase[1]}
+
+    # Extract test config parameters
+    config_str=${MDT_suite[$element]}
+    IFS=' ' ; read -ra config <<<"$config_str" 
+    min_servers=${config[0]}
+    max_servers=${config[1]}
+    targets=${config[2]}
+    ranks=${config[3]}
+    rep_type=${config[4]}
+    sw_timeout=${config[5]}
+    to_run=${config[6]}
+
+    # If a test category is to be run, calculate the number of nodes and cores based on the test type
+    # Set the desired partition to run in
+    if [ "$to_run" = YES ] ; then
+        servers=$min_servers
+        while [ "$servers" -le "$max_servers" ] ; do
+            if [ "$test_type" = "16Clnt" ] ; then
+                num_nodes=$(( $servers+17 ))
+                num_cores=$(( $num_nodes*56 ))
+                clients=16
+                num_files=12000
+            else
+                num_nodes=$(( 1+5*$servers ))
+                num_cores=$(( $num_nodes*56 ))
+                clients=$(( 4*$servers ))
+                num_files=50000
+            fi
+            if [ "$num_nodes" -le 512 ] ; then
+                partition="normal"
+            else
+                partition="large"
+            fi
+            echo Running $mdt_type with nodes=$num_nodes cores=$num_cores under partition $partition
+            sbatch $SBPARAMS -N $num_nodes  -n $num_cores -p $partition tests.sh $mdt_type $servers $clients $targets $ranks $rep_type $sw_timeout $num_files
+            servers=$(( 2*$servers ))
+        done
+    fi
+done
+}
+
+# Run the cart self tests
+run_SELF_TEST () {
 export TESTCASE=run_st_1tomany_cli2srv_inf16
 export LOGS=$RES_DIR/$(date +%Y%m%d)/$TESTCASE
 mkdir -p $LOGS
@@ -42,3 +194,19 @@ sbatch $SBPARAMS -N 66 -n 66 -p normal tests.sh SELF_TEST 64 1 1
 sbatch $SBPARAMS -N 130 -n 130 -p normal tests.sh SELF_TEST 128 1 1
 sbatch $SBPARAMS -N 258 -n 258 -p normal tests.sh SELF_TEST 256 1 1
 sbatch $SBPARAMS -N 514 -n 514 -p large tests.sh SELF_TEST 512 1 1
+}
+
+# Launch the desired tests
+for  test in "${test_array[@]}"; do
+
+    if [ "$test" == IOR ] ; then
+        run_IOR 
+    elif [ "$test" == MDT ] ; then
+        run_MDT 
+    elif [ "$test" == SELF_TEST ] ; then
+        run_self_TEST
+    else
+        echo "No test to run"
+    fi
+
+done

--- a/tests.sh
+++ b/tests.sh
@@ -8,11 +8,28 @@
 #SBATCH -A STAR-Intel           # Project Name
 #SBATCH --mail-type=all         # Send email at begin and end of job
 
-#Parameter to be updated for each sbatch
+#Parameters provided at sbatch invocation (order of parameters is important during manual testing)
+TEST=$1
 DAOS_SERVERS=$2
 DAOS_CLIENTS=$3
+
+if [ "$TEST" = SELF_TEST ] ; then
+     ST_MAX_INFLIGHT=($4)
+     ST_MIN_SRV=$(( $DAOS_SERVERS ))
+     ST_MAX_SRV=$(( $DAOS_SERVERS ))
+else
+     NUM_TARGETS=$4
+     RANKS_PER_CLIENT=$5
+     REP_CLASS=$6
+     SW_TIMEOUT=$7
+     NUM_FILES=$8
+     POOL_SIZE="85G"
+fi
+
 ACCESS_PORT=10001
-POOL_SIZE="60G"
+
+RESULT_DIR="$PWD/Log/$SLURM_JOB_ID"
+
 MPI="openmpi" #supports openmpi or mpich
 OMPI_PARAM="--mca oob ^ud --mca btl self,tcp --mca pml ob1"
 
@@ -20,16 +37,6 @@ if [ "$MPI" != "openmpi" ] && [ "$MPI" != "mpich" ]; then
     echo "Unknown MPI. Please specify either openmpi or mpich"
     exit 1
 fi
-
-#IOR Parameter
-IOR_PROC_PER_CLIENT=(4)
-TRANSFER_SIZES=(1M)
-BL_SIZE="1G"
-
-#Cart Self test parameter
-ST_MAX_INFLIGHT=($4)
-ST_MIN_SRV=$(( $DAOS_SERVERS ))
-ST_MAX_SRV=$(( $DAOS_SERVERS ))
 
 #Others
 SRUN_CMD="srun -n $SLURM_JOB_NUM_NODES -N $SLURM_JOB_NUM_NODES"
@@ -56,8 +63,12 @@ echo
 echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 echo
 
+ulimit -c unlimited
+
+# Move the logs to the defined log location using cleanup.sh
 cleanup(){
     mv *$SLURM_JOB_ID Log/$SLURM_JOB_ID/
+    mv $RESULT_FILE Log/$SLURM_JOB_ID/
     mkdir -p Log/$SLURM_JOB_ID/cleanup
     $SRUN_CMD copy_log_files.sh "cleanup"
     $SRUN_CMD cleanup.sh $DAOS_SERVERS
@@ -84,21 +95,26 @@ prepare(){
     sed -i "/^access_points/ c\access_points: ['$ACCESS_POINT:$ACCESS_PORT']" $DAOS_AGENT_YAML
     sed -i "s/^\- .*/\- $ACCESS_POINT:$ACCESS_PORT/" $DAOS_CONTROL_YAML
 
+    if [ -z $NUM_TARGETS ] ; then
+        sed -i "s/targets:.*/targets: $NUM_TARGETS/" $DAOS_SERVER_YAML
+    fi
+
     #Create the daos_agent folder
     srun -n $SLURM_JOB_NUM_NODES mkdir  /tmp/daos_agent
     srun -n $SLURM_JOB_NUM_NODES mkdir  /tmp/daos_server
-}
 
-#Prepare log folders for tests
-prepare_test_log_dir(){
-    $SRUN_CMD create_log_dir.sh $1
+    # check arp settings
+    clush  --hostfile $RESULT_DIR/daos_all_hostlist "cat /proc/sys/net/ipv4/neigh/default/gc_thresh1 ;
+    cat  /proc/sys/net/ipv4/neigh/default/gc_thresh2 ;
+    cat  /proc/sys/net/ipv4/neigh/default/gc_thresh3 " | sort >> Log/$SLURM_JOB_ID/gc_thresholds
+
 }
 
 #Start DAOS agent
 start_agent(){
     echo -e "\nCMD: Starting agent...\n"
-    cmd="clush --hostfile Log/$SLURM_JOB_ID/daos_all_hostlist
-    -f $SLURM_JOB_NUM_NODES \"
+    fanout=$(($DAOS_CLIENTS+$DAOS_SERVERS+1))
+    cmd="clush -f $fanout --hostfile $RESULT_DIR/all_hostlist \"
     export PATH=$PATH; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH;
     export CPATH=$CPATH; export DAOS_DISABLE_REQ_FWD=1;
     daos_agent -o $DAOS_AGENT_YAML -s /tmp/daos_agent\" "
@@ -111,7 +127,8 @@ start_agent(){
 #Dump attach info
 dump_attach_info(){
     echo -e "\nCMD: Dump attach info file...\n"
-    cmd="daos_agent -i -o $DAOS_AGENT_YAML dump-attachinfo -o Log/$SLURM_JOB_ID/daos_server.attach_info_tmp"
+    #cmd="daos_agent -i -o $DAOS_AGENT_YAML dump-attachinfo -o Log/$SLURM_JOB_ID/daos_server.attach_info_tmp"
+    cmd="daos_agent -i -o $DAOS_AGENT_YAML dump-attachinfo -o daos_server.attach_info_tmp"
     echo $cmd
     echo
     eval $cmd &
@@ -138,16 +155,39 @@ create_pool(){
     echo -e "\n====== POOL INFO ======"
     echo POOL_UUID: $POOL_UUID
     echo POOL_SVC : $POOL_SVC
+
+    dmg pool set-prop --pool=$POOL_UUID --name=reclaim --value=disabled -o $DAOS_CONTROL_YAML
+    sleep 10
+}
+
+#Destroy Pool
+destroy_pool() {
+    echo -e "\nCMD: Destroying pool\n"
+    cmd="dmg  pool destroy --pool=$POOL_UUID"
+    echo $cmd
+}
+
+#Query Pool
+query_pool(){
+    query_cmd="dmg  -o $DAOS_CONTROL_YAML pool query --pool $POOL_UUID"
+    start=$(date +%s.%N)
+    eval $query_cmd
+    end=$(date +%s.%N)
+    time_diff=$(echo "$end - $start" | bc)
+    query_time=`printf "%.3f seconds" $time_diff`
+    echo "Pool Query time was $query_time"
+    echo
 }
 
 #Start daos servers
 start_server(){
     echo -e "\nCMD: Starting server...\n"
-    cmd="clush --hostfile Log/$SLURM_JOB_ID/daos_server_hostlist 
+    cmd="clush --hostfile Log/$SLURM_JOB_ID/daos_server_hostlist
     -f $SLURM_JOB_NUM_NODES \"
     export PATH=$PATH; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH;
     export CPATH=$CPATH; export DAOS_DISABLE_REQ_FWD=1;
     daos_server start -i -o $DAOS_SERVER_YAML --recreate-superblocks \" 2>&1 "
+
     echo $cmd
     echo
     eval $cmd &
@@ -160,47 +200,142 @@ start_server(){
 #Run IOR
 run_ior(){
     echo -e "\nCMD: Starting IOR..."
-    for size in "${TRANSFER_SIZES[@]}"; do
-        for i in "${IOR_PROC_PER_CLIENT[@]}"; do
-            no_of_ps=$(($DAOS_CLIENTS * $i))
-	    echo
 
-	    ior_cmd="ior
-                 -a DAOS -b $BL_SIZE  -w -r -i 2 -o daos:testFile 
-                 -t $size --daos.cont $(uuidgen) --daos.destroy
-                 --daos.group daos_server --daos.pool $POOL_UUID
-                 --daos.svcl $POOL_SVC -vv"
+        TEST_TYPE="${TEST#IOR}"
+        RESULT_FILE="ior-$TEST_TYPE-S$DAOS_SERVERS-T$NUM_TARGETS-C$DAOS_CLIENTS-P$RANKS_PER_CLIENT"
+        no_of_procs=$(($DAOS_CLIENTS*$RANKS_PER_CLIENT))
+        pool_size=85
+        NUM_ITERS=1
 
-            mpich_cmd="mpirun
-		 -np $no_of_ps -map-by node 
-                 -hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
-		 $ior_cmd"
+        if [ "$TEST_TYPE" = "easy" ] ; then
+            XFER_SIZE=1m
+            BL_SIZE=150g
+            segments=1
+        else
+            XFER_SIZE="47008"
+            BL_SIZE="47008"
+            segments=2000000
+        fi
 
-	    openmpi_cmd="orterun $OMPI_PARAM 
-		 -x CPATH -x PATH -x LD_LIBRARY_PATH
-		 -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-                 --timeout 600 -np $no_of_ps --map-by node 
-                 --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
-		 $ior_cmd" 
+        query_pool
 
-	    if [ "$MPI" == "openmpi" ]; then
-		cmd=$openmpi_cmd
-	    else
-		cmd=$mpich_cmd
-	    fi
+        echo num_servers: $DAOS_SERVERS "  " num_targets: $NUM_TARGETS "  "num_clients: $DAOS_CLIENTS "  " procs_per_client: $RANKS_PER_CLIENT | tee  -a $RESULT_FILE
+        echo
 
-            echo $cmd
-	    echo
-            eval $cmd
-            if [ $? -ne 0 ]; then
-                echo -e "\nSTATUS: transfer_size=$size, process_per_client=$i - IOR FAIL\n"
-                exit 1
-            else
-                echo -e "\nSTATUS: transfer_size=$size, process_per_client=$i - IOR SUCCESS\n"
-            fi
-	    sleep 5
-        done
-    done
+        cont_create=`daos cont create --pool=$POOL_UUID --svc=$POOL_SVC --type=POSIX --properties=dedup:memcmp`
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            echo "CONT Create FAIL"
+            exit 1
+        else
+            echo "CONT Create Success"
+        fi
+
+        echo cont: $cont_create
+        CONT_UUID=`awk '{print $4}' <<< "$cont_create"`
+
+        daos cont query --pool=$POOL_UUID --svc=$POOL_SVC --cont=$CONT_UUID
+
+        ior_wr_cmd="ior
+             -a DFS -b $BL_SIZE -C -e -w -W -g -G 27 -k -i $NUM_ITERS -s $segments -o /testFile
+             -O stoneWallingWearOut=1 -O stoneWallingStatusFile=$PWD/sw.$SLURM_JOB_ID  -D $SW_TIMEOUT
+             -d 5 -t $XFER_SIZE --dfs.cont $CONT_UUID
+             --daos.group daos_server --dfs.pool $POOL_UUID --dfs.oclass $REP_CLASS
+             --dfs.svcl $POOL_SVC  -vvv 2>&1 | tee -a $RESULT_FILE "
+
+        ior_rd_cmd="ior
+             -a DFS -b $BL_SIZE  -C -Q 1 -e -r -R -g -G 27 -k -i $NUM_ITERS -s $segments -o /testFile
+             -O stoneWallingStatusFile=$PWD/sw.$SLURM_JOB_ID
+             -d 5 -t $XFER_SIZE --dfs.cont $CONT_UUID
+             --daos.group daos_server --dfs.pool $POOL_UUID --dfs.oclass $REP_CLASS
+             --dfs.svcl $POOL_SVC  -vvv 2>&1 | tee -a $RESULT_FILE "
+
+        mpich_prefix="mpirun
+             -np $no_of_procs -map-by node
+             -hostfile $RESULT_DIR/daos_client_hostlist "
+
+        openmpi_prefix="orterun $OMPI_PARAM
+             -x CPATH -x PATH -x LD_LIBRARY_PATH
+             -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
+             --timeout 1800 -np $no_of_procs --map-by node
+             --hostfile $RESULT_DIR/daos_client_hostlist "
+
+        if [ "$MPI" == "openmpi" ]; then
+            prefix=$openmpi_prefix
+        else
+            prefix=$mpich_prefix
+        fi
+
+        cmd="$prefix $ior_wr_cmd ; sleep 5 ; $prefix  $ior_rd_cmd"
+
+        echo $cmd
+        echo
+        eval $cmd
+
+        if [ $? -ne 0 ]; then
+            echo -e "\nSTATUS: agg_size:$agg_size, block_size:$BL_SIZE transfer_size:$XFER_SIZE - IOReasy FAIL\n"
+        else
+            echo -e "\nSTATUS: agg_size:$agg_size, block_size:$BL_SIZE transfer_size:$XFER_SIZE - IOReasy SUCCESS\n"
+        fi
+
+        query_pool
+}
+
+#Run mdtest
+run_mdtest(){
+    echo -e "\nCMD: Starting MDTEST ...\n"
+        echo
+        TEST_TYPE="${TEST#MDT}"
+        no_of_procs=$(($DAOS_CLIENTS * $RANKS_PER_CLIENT))
+        RESULT_FILE="mdtest-$TEST_TYPE-S$DAOS_SERVERS-T$NUM_TARGETS-C$DAOS_CLIENTS-P$RANKS_PER_CLIENT"
+
+        if [ "$TEST_TYPE" = "easy" ] ; then
+            num_files=$(($NUM_FILES*7/2))
+            params=" -u -L "
+        else
+            num_files=$NUM_FILES
+            params=" -w 3901 -e 3901 -t -z 0/20 "
+        fi
+
+        query_pool
+
+        echo num_servers: $DAOS_SERVERS "  " num_targets: $NUM_TARGETS "  "num_clients: $DAOS_CLIENTS "  " procs_per_client: $RANKS_PER_CLIENT | tee  -a $RESULT_FILE
+        echo
+
+        mdtest_cmd="mdtest
+             -a DFS --dfs.destroy --dfs.pool $POOL_UUID
+             --dfs.cont $(uuidgen) --dfs.svcl $POOL_SVC $params
+             -p 10 -n $num_files -F --dfs.oclass S1 -N 1 -P -d / -W 300 -x sw.$SLURM_JOB_ID
+             2>&1 | tee  -a $RESULT_FILE"
+
+        mpich_cmd="mpirun
+             -np $no_of_procs -map-by node
+             -hostfile $RESULT_DIR/daos_client_hostlist
+             $mdtest_cmd"
+
+        openmpi_cmd="orterun $OMPI_PARAM
+             -x CPATH -x PATH -x LD_LIBRARY_PATH
+             -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
+             --timeout 1800 -np $no_of_procs --map-by node
+             --hostfile $RESULT_DIR/daos_client_hostlist
+             $mdtest_cmd"
+
+        if [ "$MPI" == "openmpi" ]; then
+            cmd=$openmpi_cmd
+        else
+            cmd=$mpich_cmd
+        fi
+
+        echo $cmd
+        echo
+        eval $cmd
+        if [ $? -ne 0 ]; then
+            echo -e "\nSTATUS: MDTESTeasy FAIL\n"
+        else
+            echo -e "\nSTATUS: MDTESTeasy SUCCESS\n"
+        fi
+
+        query_pool
 }
 
 #Run cart self_test
@@ -251,74 +386,39 @@ run_self_test(){
     done
 }
 
-run_mdtest(){
-    echo -e "\nCMD: Starting MDTEST...\n"
-    for i in "${IOR_PROC_PER_CLIENT[@]}"; do
-	no_of_ps=$(($DAOS_CLIENTS * $i))
-	echo
-        mdtest_cmd="mdtest
-             -a DFS --dfs.destroy --dfs.pool $POOL_UUID 
-             --dfs.cont $(uuidgen) --dfs.svcl $POOL_SVC
-             -n 500  -u -L --dfs.oclass S1 -N 1 -P -d /"
-
-        mpich_cmd="mpirun
-             -np $no_of_ps -map-by node 
-             -hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
-             $mdtest_cmd"
-
-        openmpi_cmd="orterun $OMPI_PARAM 
-             -x CPATH -x PATH -x LD_LIBRARY_PATH
-             -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-             --timeout 600 -np $no_of_ps --map-by node 
-             --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
-             $mdtest_cmd"
-
-        if [ "$MPI" == "openmpi" ]; then
-            cmd=$openmpi_cmd
-        else
-            cmd=$mpich_cmd
-        fi
-
-        echo $cmd
-	echo
-        eval $cmd
-        if [ $? -ne 0 ]; then
-            echo -e "\nSTATUS: process_per_client=$i - MDTEST FAIL\n"
-            exit 1
-        else
-            echo -e "\nSTATUS: process_per_client=$i - MDTEST SUCCESS\n"
-        fi
-    done
-}
-
 #Prepare Enviornment
 prepare
 
-test=$1
 
 echo "###################"
-echo "RUN: $TESTCASE"
+echo "RUN: $TEST"
 echo "###################"
 
-case $test in
-    IOR)
+echo $TEST
+
+case $TEST in
+    IOR*)
         start_server
         start_agent
         create_pool
         run_ior
+        sleep 20
+        destroy_pool
         ;;
+    MDT*)
+        start_server
+        start_agent
+        create_pool
+        run_mdtest
+        sleep 20
+        destroy_pool
+        ;;  
     SELF_TEST)
         start_server
         dump_attach_info
         run_self_test
         ;;
-    MDTEST)
-        start_server
-        start_agent
-        create_pool
-        run_mdtest
-        ;;  
     *)
-        echo "Unknown test: Please use IOR, SELF_TEST or MDTEST"
+        echo "Unknown test: Please use IOReasy, IORhard, MDTeasy, MDThard or SELF_TEST"
 esac
 


### PR DESCRIPTION
…tion

The following changes provide test automation infrastructure.

testlist.sh Added IOR and MDTEST test suites. Defined associative arrays
for them. Each element defines a test case under a test category with
corresponding parameters in the value field. A YES/NO flag is added to
the parameters to turn on and off a specific test category.  New tests
can be added to the suite with needed modification to the run functions.
The sbatch commands need to match the requirements of tests.sh

tests.sh Modified run_ior and run_mdtest to be able to run easy and hard
test cases with stone walling as wll as handle replication class passed.

daos_server.yml  Made FI_UNIVERSE_SIZE as 16000. Also mase ERROR as
default mask.  Can be turned on to DEBUG as needed.

cleanup.sh Changed the output log file name format to
log-Sxxx-<slurm job id> This has been done for compatibility with
post processing scripts.

openmpi_gen_hostlist.sh Created all_hostlist (that includes the launch
node also found necessary while testing) and slots=1 to server hostlist.

Signed-off-by: hpcarchitect <aruna.ramanan@intel.com>