### PR TITLE
DAOS-5723 Automate IOR hard on Frontera for weekly run

### DIFF
--- a/build_env.sh
+++ b/build_env.sh
@@ -2,13 +2,6 @@
 
 MPI_TARGET=${1}
 
-
-# Custom parameters
-
-MPICH_DIR="<path_to_mpich>" #e.g./scratch/POC/mpich
-OPENMPI_DIR="<path_to_openmpi>" #e.g./scratch/POC/openmpi
-
-
 # Activate mpi
 
 function activate_mpi(){

--- a/get_ior_results.sh
+++ b/get_ior_results.sh
@@ -19,11 +19,15 @@ current=${PWD##*/}
 echo $current
 
 #Output file
-result="$RES_DIR/result_$current"
+result=${RES_DIR}/result_${current}.csv
 
 # Extract results from test logs
 
-echo Num_Servers,Targets,Clients,Ranks,Write-Easy,Read-Easy > $result
+function get_value(){
+    grep -E "^${1}[[:space:]]*:\s" ${2} | cut -d ':' -f 2 | tr -d ' '
+}
+
+echo "Servers,Clients,PPC,Ranks,Scenario,Max Write (GiB/sec),Max Read (GiB/sec),Status" > ${result}
 
 # For each directory in the curret dir, if the name starts with log
 # get the run configuration parameters 
@@ -33,20 +37,22 @@ echo Num_Servers,Targets,Clients,Ranks,Write-Easy,Read-Easy > $result
 for i in *
 do
     if [ -d "$i" ] && [[ "$i" = log* ]]; then
-       str=`grep num_servers ./$i/stdout*`
-       servers=`awk '{print $2}' <<< "$str"`
-       targets=`awk '{print $4}' <<< "$str"`
-       clients=`awk '{print $6}' <<< "$str"`
-       ranks=`awk '{print $8}' <<< "$str"`
-       if [ -f "$i"/ior* ] && grep "Max Write" "$i"/ior* ; then
-           wr=`grep  "Max Write" ./$i/ior* | awk '{print $3}'`
-           rd=`grep "Max Read" ./$i/ior* | awk '{print $3}'`
-           wr_GiB=`echo "scale=2;$wr / 1024" | bc`
-           rd_GiB=`echo "scale=2;$rd / 1024" | bc`
-           echo "$servers","$wr_GiB","$rd_GiB","$wr","$rd" >> $result
-       else
-          echo "$servers",0,0,0,0 >> $result
-       fi
+        CURRENT_FILE=${RES_DIR}/$i/stdout*
+        SERVERS=$(grep -E "^DAOS_SERVERS=" ${CURRENT_FILE} | cut -d '=' -f 2 | tr -d ' ')
+        CLIENTS=$(get_value 'nodes' ${CURRENT_FILE})
+        RANKS=$(get_value 'tasks' ${CURRENT_FILE})
+        PPC=$(get_value 'clients per node' ${CURRENT_FILE})
+        SCENARIO=$(get_value 'RUN' ${CURRENT_FILE})
+
+        if [ -f "$i"/stdout* ] && grep -q "Max Write" "$i"/stdout* ; then
+            wr=`grep "Max Write" ./$i/stdout* | awk '{print $3}'`
+            rd=`grep "Max Read" ./$i/stdout* | awk '{print $3}'`
+            wr_GiB=`echo "scale=2;$wr / 1024" | bc`
+            rd_GiB=`echo "scale=2;$rd / 1024" | bc`
+            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},${wr_GiB},${rd_GiB},Passed" >> ${result}
+        else
+            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},0,0,Failed" >> ${result}
+        fi
     fi
 done
 

--- a/get_ior_results.sh
+++ b/get_ior_results.sh
@@ -27,7 +27,7 @@ function get_value(){
     grep -E "^${1}[[:space:]]*:\s" ${2} | cut -d ':' -f 2 | tr -d ' '
 }
 
-echo "Servers,Clients,PPC,Ranks,Scenario,Max Write (GiB/sec),Max Read (GiB/sec),Status" > ${result}
+echo "Servers,Clients,PPC,Ranks,Scenario,Max Write (GiB/sec),Max Read (GiB/sec),Start,End,Status" > ${result}
 
 # For each directory in the curret dir, if the name starts with log
 # get the run configuration parameters 
@@ -43,15 +43,17 @@ do
         RANKS=$(get_value 'tasks' ${CURRENT_FILE})
         PPC=$(get_value 'clients per node' ${CURRENT_FILE})
         SCENARIO=$(get_value 'RUN' ${CURRENT_FILE})
+        START_TIME=$(grep -E "^Start Time:\s" ${CURRENT_FILE} | sed "s/Start Time: //g")
+        END_TIME=$(grep -E "^End Time:\s" ${CURRENT_FILE} | sed "s/End Time: //g")
 
         if [ -f "$i"/stdout* ] && grep -q "Max Write" "$i"/stdout* ; then
             wr=`grep "Max Write" ./$i/stdout* | awk '{print $3}'`
             rd=`grep "Max Read" ./$i/stdout* | awk '{print $3}'`
             wr_GiB=`echo "scale=2;$wr / 1024" | bc`
             rd_GiB=`echo "scale=2;$rd / 1024" | bc`
-            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},${wr_GiB},${rd_GiB},Passed" >> ${result}
+            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},${wr_GiB},${rd_GiB},${START_TIME},${END_TIME},Passed" >> ${result}
         else
-            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},0,0,Failed" >> ${result}
+            echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},0,0,${START_TIME},${END_TIME},Failed" >> ${result}
         fi
     fi
 done

--- a/run_build.sh
+++ b/run_build.sh
@@ -19,8 +19,6 @@ declare -a PRECIOUS_FILES=("bin/daos"
                            "bin/dmg"
                            "ior${MPI_SUFFIX}/bin/ior"
                            "ior${MPI_SUFFIX}/bin/mdtest"
-                           "ior${MPI_SUFFIX}/bin/ior"
-                           "ior${MPI_SUFFIX}/bin/mdtest"
                            )
 
 function basic_check() {

--- a/run_build.sh
+++ b/run_build.sh
@@ -4,6 +4,10 @@ export BUILD_DIR="<path_build_area>" #e.g./scratch/POC/BUILDS/
 export IOR_DIR="<path_to_ior_repo>" #e.g./scratch/POC/ior-hpc
 export MPI_DIR="<path_to_mpi>" #e.g./scratch/POC/mpi
 
+# Unload modules that are not needed on Frontera
+module unload impi pmix hwloc
+module list
+
 folder=$(date +%Y%m%d)
 rm -rf $BUILD_DIR/$folder
 mkdir -p $BUILD_DIR/$folder

--- a/run_build.sh
+++ b/run_build.sh
@@ -2,13 +2,44 @@
 
 export BUILD_DIR="<path_build_area>" #e.g./scratch/POC/BUILDS/
 export IOR_DIR="<path_to_ior_repo>" #e.g./scratch/POC/ior-hpc
-export MPI_DIR="<path_to_mpi>" #e.g./scratch/POC/mpi
 
 # Unload modules that are not needed on Frontera
 module unload impi pmix hwloc
 module list
 
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LATEST_DAOS=${BUILD_DIR}/latest/daos/install
 folder=$(date +%Y%m%d)
+
+source ${CURRENT_DIR}/source_me.sh openmpi
+
+declare -a PRECIOUS_FILES=("bin/daos"
+                           "bin/daos_server"
+                           "bin/daos_agent"
+                           "bin/dmg"
+                           "ior${MPI_SUFFIX}/bin/ior"
+                           "ior${MPI_SUFFIX}/bin/mdtest"
+                           "ior${MPI_SUFFIX}/bin/ior"
+                           "ior${MPI_SUFFIX}/bin/mdtest"
+                           )
+
+function basic_check() {
+  for i in "${PRECIOUS_FILES[@]}"
+  do
+    CURRENT_FILE=${LATEST_DAOS}/${i}
+
+    if [ ! -f ${CURRENT_FILE} ]; then
+      echo "Error: missing file ${CURRENT_FILE}"
+      exit 1
+    fi
+
+    if ! ldd ${CURRENT_FILE} | grep -q daos ; then
+      echo "Error: file ${CURRENT_FILE} does not link DAOS libraries"
+      exit 1
+    fi
+  done
+}
+
 rm -rf $BUILD_DIR/$folder
 mkdir -p $BUILD_DIR/$folder
 
@@ -22,15 +53,24 @@ git submodule init
 git submodule update
 git merge --no-edit origin/tanabarr/control-no-ipmctl-May2020
 git merge --no-edit origin/mjmac/allow-fwd-disable-20200508
-scons --build-deps=yes --config=force install
+scons MPI_PKG=any --build-deps=yes --config=force install
 popd
 popd
 popd
 
+
+
 pushd $IOR_DIR
 ./bootstrap
-./configure --prefix=$BUILD_DIR/latest/daos/install/ior_openmpi --with-daos=$BUILD_DIR/latest/daos/install --with-cart=$BUILD_DIR/latest/daos/install MPICC=$MPI_DIR/bin/mpicc CPPFLAGS="-I$BUILD_DIR/latest/daos/install/prereq/dev/mercury/include -I$MPI_DIR/include" LDFLAGS=-L$MPI_DIR/lib LIBS=-lmpi
+./configure --prefix=${LATEST_DAOS}/ior${MPI_SUFFIX} \
+            --with-daos=${LATEST_DAOS} \
+            --with-cart=${LATEST_DAOS} \
+            CPPFLAGS=-I${LATEST_DAOS}/prereq/dev/mercury/include \
+            LIBS=-lmpi
 make clean
 make
 make install
 popd
+
+# Perform a basic revision of the built binaries
+basic_check ${LATEST_DAOS}/ior${MPI_SUFFIX}/bin/ior

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -9,11 +9,13 @@ env['PATH'] = "/opt/apps/xalt/xalt/bin:/opt/apps/intel19/python3/3.7.0/bin:/opt/
 
 env['LD_LIBRARY_PATH'] = "/opt/apps/intel19/python3/3.7.0/lib:/opt/intel/debugger_2019/libipt/intel64/lib:/opt/intel/compilers_and_libraries_2019.5.281/linux/daal/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64_lin/gcc4.7:/opt/intel/compilers_and_libraries_2019.5.281/linux/mkl/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/apps/gcc/8.3.0/lib64:/opt/apps/gcc/8.3.0/lib:/usr/lib64/:/usr/lib64/"
 
-env['JOBNAME']  = "<sbatch_jobname>"
-env['EMAIL']    = "<email>" #<first.last@email.com>
-env['DAOS_DIR'] = "<path_to_daos>" #/scratch/BUILDS/latest/daos
-env['DST_DIR']  = "<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
-env['RES_DIR']  = "<path_to_result_dir>" #/home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
+env['JOBNAME']    = "<sbatch_jobname>"
+env['EMAIL']      = "<email>" #<first.last@email.com>
+env['DAOS_DIR']   = "<path_to_daos>" #/scratch/BUILDS/latest/daos
+env['DST_DIR']    = "<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
+env['RES_DIR']    = "<path_to_result_dir>" #/home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
+env['MPICH_DIR']  = "<path_to_mpich>" #e.g./scratch/POC/mpich
+env['OPENMPI_DIR']= "<path_to_openmpi>" #e.g./scratch/POC/openmpi
 
 slf_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                  'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -9,11 +9,11 @@ env['PATH'] = "/opt/apps/xalt/xalt/bin:/opt/apps/intel19/python3/3.7.0/bin:/opt/
 
 env['LD_LIBRARY_PATH'] = "/opt/apps/intel19/python3/3.7.0/lib:/opt/intel/debugger_2019/libipt/intel64/lib:/opt/intel/compilers_and_libraries_2019.5.281/linux/daal/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64_lin/gcc4.7:/opt/intel/compilers_and_libraries_2019.5.281/linux/mkl/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/apps/gcc/8.3.0/lib64:/opt/apps/gcc/8.3.0/lib:/usr/lib64/:/usr/lib64/"
 
-env['JOBNAME'] = "<sbatch_jobname>"
-env['EMAIL'] = "<email>"  # <first.last@email.com>
-env['DAOS_DIR'] = "<path_to_daos>"  # /scratch/BUILDS/latest/daos
-env['DST_DIR'] = "<path_to_daos_scaled_testing>" # /scratch/TESTS/daos_scaled_testing
-env['RES_DIR'] = "<path_to_result_dir>" # /home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
+env['JOBNAME']  = "<sbatch_jobname>"
+env['EMAIL']    = "<email>" #<first.last@email.com>
+env['DAOS_DIR'] = "<path_to_daos>" #/scratch/BUILDS/latest/daos
+env['DST_DIR']  = "<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
+env['RES_DIR']  = "<path_to_result_dir>" #/home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
 
 slf_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                  'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],
@@ -61,7 +61,7 @@ ior_testlist = [{'testcase': 'ioreasy_1to4',
                  'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
                  'nClient': [8, 16, 32, 64, 128, 256, 512, 1024],
                  # timeout in minutes
-                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15],
+                 'timeout': [15, 15, 15, 15, 120, 120, 120, 120],
                  'ppc': 32,
                  'pool_sz': '85G',
                  'xfer_sz': '47008',

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -9,112 +9,138 @@ env['PATH'] = "/opt/apps/xalt/xalt/bin:/opt/apps/intel19/python3/3.7.0/bin:/opt/
 
 env['LD_LIBRARY_PATH'] = "/opt/apps/intel19/python3/3.7.0/lib:/opt/intel/debugger_2019/libipt/intel64/lib:/opt/intel/compilers_and_libraries_2019.5.281/linux/daal/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64_lin/gcc4.7:/opt/intel/compilers_and_libraries_2019.5.281/linux/mkl/lib/intel64_lin:/opt/intel/compilers_and_libraries_2019.5.281/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/apps/gcc/8.3.0/lib64:/opt/apps/gcc/8.3.0/lib:/usr/lib64/:/usr/lib64/"
 
-env['JOBNAME']  = "<sbatch_jobname>"
-env['EMAIL']    = "<email>" #<first.last@email.com>
-env['DAOS_DIR'] = "<path_to_daos>" #/scratch/BUILDS/latest/daos
-env['DST_DIR']  = "<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
-env['RES_DIR']  = "<path_to_result_dir>" #/home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
+env['JOBNAME'] = "<sbatch_jobname>"
+env['EMAIL'] = "<email>"  # <first.last@email.com>
+env['DAOS_DIR'] = "<path_to_daos>"  # /scratch/BUILDS/latest/daos
+env['DST_DIR'] = "<path_to_daos_scaled_testing>" # /scratch/TESTS/daos_scaled_testing
+env['RES_DIR'] = "<path_to_result_dir>" # /home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
 
-slf_testlist = [ { 'testcase': 'st_1tomany_cli2srv_inf1',
-               'nServer' : [ 2,  4,  8, 16, 32, 64, 128, 256, 512],
-               'nClient' : [ 1,  1,  1,  1,  1,  1,   1,   1,   1],
-               'timeout' : [15, 15, 15, 15, 15, 15,  15,  15,  15], #timeout in minutes
-               'ppc'     : 1,
-               'inflight': 1,
-               'enabled' : 0
-             },
-             { 'testcase': 'st_1tomany_cli2srv_inf16',
-               'nServer' : [ 2,  4,  8, 16, 32, 64, 128, 256, 512],
-               'nClient' : [ 1,  1,  1,  1,  1,  1,   1,   1,   1],
-               'timeout' : [15, 15, 15, 15, 15, 15,  15,  15,  15], #timeout in minutes
-               'ppc'     : 1,
-               'inflight': 16,
-               'enabled' : 0
-             }
-            ]
+slf_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
+                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],
+                 'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15],
+                 'ppc': 1,
+                 'inflight': 1,
+                 'enabled': 0
+                 },
+                {'testcase': 'st_1tomany_cli2srv_inf16',
+                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],
+                 'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15],
+                 'ppc': 1,
+                 'inflight': 16,
+                 'enabled': 0
+                 }
+                ]
 
-ior_testlist = [ { 'testcase': 'ioreasy_1to4',
-               'nServer' : [ 2,  4,  8, 16],
-               'nClient' : [ 8, 16, 32, 64],
-               'timeout' : [15, 15, 15, 15], #timeout in minutes
-               'ppc'     : 32,
-               'pool_sz' : '85G',
-               'xfer_sz' : '1M',
-               'blk_sz'  : '1G',
-               'enabled' : 0
-             },
-             { 'testcase': 'ioreasy_c16',
-               'nServer' : [ 2,  4,  8, 16],
-               'nClient' : [16, 16, 16, 16],
-               'timeout' : [15, 15, 15, 15], #timeout in minutes
-               'ppc'     : 32,
-               'pool_sz' : '85G',
-               'xfer_sz' : '1M',
-               'blk_sz'  : '1G',
-               'enabled' : 0
-             }
-            ]
+ior_testlist = [{'testcase': 'ioreasy_1to4',
+                 'nServer': [2, 4, 8, 16],
+                 'nClient': [8, 16, 32, 64],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15],
+                 'ppc': 32,
+                 'pool_sz': '85G',
+                 'xfer_sz': '1M',
+                 'blk_sz': '1G',
+                 'enabled': 0
+                 },
+                {'testcase': 'ioreasy_c16',
+                 'nServer': [2, 4, 8, 16],
+                 'nClient': [16, 16, 16, 16],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15],
+                 'ppc': 32,
+                 'pool_sz': '85G',
+                 'xfer_sz': '1M',
+                 'blk_sz': '1G',
+                 'enabled': 0
+                 },
+                {'testcase': 'iorhard_1to4',
+                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
+                 'nClient': [8, 16, 32, 64, 128, 256, 512, 1024],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15],
+                 'ppc': 32,
+                 'pool_sz': '85G',
+                 'xfer_sz': '47008',
+                 'blk_sz': '47008',
+                 'enabled': 0
+                 },
+                {'testcase': 'iorhard_c16',
+                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
+                 'nClient': [16, 16, 16, 16, 16, 16, 16, 16],
+                 # timeout in minutes
+                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15],
+                 'ppc': 32,
+                 'pool_sz': '85G',
+                 'xfer_sz': '47008',
+                 'blk_sz': '47008',
+                 'enabled': 0
+                 }
+                ]
 
 dst_dir = os.getenv("DST_DIR")
 script = os.path.join(dst_dir, "run_sbatch.sh")
 
 for test in slf_testlist:
     if test['enabled'] == 1:
-         env['TEST_GROUP'] = "SELF_TEST"
-         env['TESTCASE'] = test['testcase']
-         env['INFLIGHT'] = str(test['inflight'])
-         for i in range(len(test['nServer'])):
-             srv = test['nServer'][i]
-             cli = test['nClient'][i]
-             nodes = srv + cli + 1
-             cores = nodes * test['ppc']
-             if nodes <= 512:
-                 env['PARTITION'] = 'normal'
-             else:
-                 env['PARTITION'] = 'large'
+        env['TEST_GROUP'] = "SELF_TEST"
+        env['TESTCASE'] = test['testcase']
+        env['INFLIGHT'] = str(test['inflight'])
+        for i in range(len(test['nServer'])):
+            srv = test['nServer'][i]
+            cli = test['nClient'][i]
+            nodes = srv + cli + 1
+            cores = nodes * test['ppc']
+            if nodes <= 512:
+                env['PARTITION'] = 'normal'
+            else:
+                env['PARTITION'] = 'large'
 
-             env['DAOS_SERVERS'] = str(srv)
-             env['DAOS_CLIENTS'] = str(cli)
-             env['NNODE'] = str(nodes)
-             env['NCORE'] = str(cores)
+            env['DAOS_SERVERS'] = str(srv)
+            env['DAOS_CLIENTS'] = str(cli)
+            env['NNODE'] = str(nodes)
+            env['NCORE'] = str(cores)
 
-             t = test['timeout'][i] + 10
-             h = int(t/60)
-             m = t%60
-             s = 0
-             env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-             env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+            t = test['timeout'][i] + 10
+            h = int(t / 60)
+            m = t % 60
+            s = 0
+            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
+            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
 
-             subprocess.Popen(script, env=env)
+            subprocess.Popen(script, env=env)
 
 for test in ior_testlist:
     if test['enabled'] == 1:
-         env['TEST_GROUP'] = "IOR"
-         env['TESTCASE'] = test['testcase']
-         for i in range(len(test['nServer'])):
-             srv = test['nServer'][i]
-             cli = test['nClient'][i]
-             nodes = srv + cli + 1
-             cores = nodes * test['ppc']
-             if nodes <= 512:
-                 env['PARTITION'] = 'normal'
-             else:
-                 env['PARTITION'] = 'large'
+        env['TEST_GROUP'] = "IOR"
+        env['TESTCASE'] = test['testcase']
+        for i in range(len(test['nServer'])):
+            srv = test['nServer'][i]
+            cli = test['nClient'][i]
+            nodes = srv + cli + 1
+            cores = nodes * test['ppc']
+            if nodes <= 512:
+                env['PARTITION'] = 'normal'
+            else:
+                env['PARTITION'] = 'large'
 
-             env['DAOS_SERVERS'] = str(srv)
-             env['DAOS_CLIENTS'] = str(cli)
-             env['NNODE'] = str(nodes)
-             env['NCORE'] = str(cores)
-             env['PPC'] = str(test['ppc'])
-             env['POOL_SIZE'] = test['pool_sz']
-             env['XFER_SIZE'] = test['xfer_sz']
-             env['BLOCK_SIZE'] = test['blk_sz']
+            env['DAOS_SERVERS'] = str(srv)
+            env['DAOS_CLIENTS'] = str(cli)
+            env['NNODE'] = str(nodes)
+            env['NCORE'] = str(cores)
+            env['PPC'] = str(test['ppc'])
+            env['POOL_SIZE'] = test['pool_sz']
+            env['XFER_SIZE'] = test['xfer_sz']
+            env['BLOCK_SIZE'] = test['blk_sz']
 
-             t = test['timeout'][i] + 10
-             h = int(t/60)
-             m = t%60
-             s = 0
-             env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-             env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+            t = test['timeout'][i] + 10
+            h = int(t / 60)
+            m = t % 60
+            s = 0
+            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
+            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
 
-             subprocess.Popen(script, env=env)
+            subprocess.Popen(script, env=env)

--- a/run_weekly.sh
+++ b/run_weekly.sh
@@ -2,5 +2,10 @@
 
 DST_DIR="<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
 
-$DST_DIR/run_build.sh
-$DST_DIR/run_testlist.py
+${DST_DIR}/run_build.sh
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to build artifacts"
+  exit 1
+fi
+
+${DST_DIR}/run_testlist.py

--- a/source_me.sh
+++ b/source_me.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+MPI_TARGET=${1}
+
+
+# Custom parameters
+
+MPICH_DIR="<path_to_mpich>" #e.g./scratch/POC/mpich
+OPENMPI_DIR="<path_to_openmpi>" #e.g./scratch/POC/openmpi
+
+
+# Activate mpi
+
+function activate_mpi(){
+  NAME=${1}
+  MPI_DIR=${2}
+
+  export PATH=${MPI_DIR}/bin:${PATH}
+  export LD_LIBRARY_PATH=${MPI_DIR}/lib:${LD_LIBRARY_PATH}
+  export PKG_CONFIG_PATH=${MPI_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}
+  export MPI_BIN=${MPI_DIR}/bin
+  export MPI_INCLUDE=${MPI_DIR}/include
+  export MPI_LIB=${MPI_DIR}/lib
+  export MPI_COMPILER=${NAME}
+  export MPI_SUFFIX=_${NAME}
+  export MPI_HOME=${MPI_DIR}
+}
+
+if [ -z "${MPI_TARGET}" ]; then
+  MPI_TARGET=openmpi
+  echo "Using default option: ${MPI_TARGET}"
+fi
+
+case ${MPI_TARGET} in
+  openmpi)
+    activate_mpi ${MPI_TARGET} ${OPENMPI_DIR}
+    VER=`ompi_info | grep "Open MPI:" | cut -d ":" -f 2 | sed -e 's/^[[:space:]]*//'`
+    echo "Open MPI Version: ${VER}"
+    ;;
+  mpich)
+    activate_mpi ${MPI_TARGET} ${MPICH_DIR}
+    VER=`mpichversion | grep "MPICH Version:" | cut -d ":" -f 2 | sed -e 's/^[[:space:]]*//'`
+    echo "MPICH Version: ${VER}"
+    ;;
+  *)
+    echo "Error unknown target \"${MPI_TARGET}\": openmpi or mpich"
+esac

--- a/tests.sh
+++ b/tests.sh
@@ -42,10 +42,8 @@ pushd $DAOS_DIR
 git log | head -n 1
 popd
 echo
-source env_daos $DAOS_DIR
-
-export PATH=~/utils/install/$MPI/bin:$PATH
-export LD_LIBRARY_PATH=~/utils/install/$MPI/lib:$LD_LIBRARY_PATH
+source ${DST_DIR}/env_daos ${DAOS_DIR}
+source ${DST_DIR}/build_env.sh ${MPI}
 
 export PATH=$DAOS_DIR/install/ior_$MPI/bin:$PATH
 export LD_LIBRARY_PATH=$DAOS_DIR/install/ior_$MPI/lib:$LD_LIBRARY_PATH

--- a/tests.sh
+++ b/tests.sh
@@ -62,6 +62,7 @@ cleanup(){
     mkdir -p Log/$SLURM_JOB_ID/cleanup
     $SRUN_CMD copy_log_files.sh "cleanup"
     $SRUN_CMD cleanup.sh $DAOS_SERVERS
+    echo "End Time: $(date)"
 }
 
 trap cleanup EXIT
@@ -250,14 +251,14 @@ run_ior(){
              --dfs.svcl $POOL_SVC -vv"
 
     mpich_cmd="mpirun
-             -np $no_of_ps -map-by node 
+             -np $no_of_ps -map-by node
              -hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
 	     $ior_cmd"
 
     openmpi_cmd="orterun $OMPI_PARAM 
 		 -x CPATH -x PATH -x LD_LIBRARY_PATH
 		 -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-                 --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node 
+                 --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node
                  --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
 		 $ior_cmd" 
 
@@ -292,14 +293,14 @@ run_self_test(){
         --max-inflight-rpcs $INFLIGHT --repetitions 100 -t -n"
 
     mpich_cmd="mpirun --prepend-rank
-        -np 1 -map-by node 
+        -np 1 -map-by node
         -hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
         $st_cmd"
 
     openmpi_cmd="orterun $OMPI_PARAM 
         -x CPATH -x PATH -x LD_LIBRARY_PATH -x FI_MR_CACHE_MAX_COUNT
         -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-        --timeout $OMPI_TIMEOUT -np 1 --map-by node 
+        --timeout $OMPI_TIMEOUT -np 1 --map-by node
         --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
         $st_cmd"
 
@@ -324,22 +325,22 @@ run_self_test(){
 run_mdtest(){
     echo -e "\nCMD: Starting MDTEST...\n"
     for i in "${IOR_PROC_PER_CLIENT[@]}"; do
-	no_of_ps=$(($DAOS_CLIENTS * $i))
-	echo
+       no_of_ps=$(($DAOS_CLIENTS * $i))
+       echo
         mdtest_cmd="mdtest
-             -a DFS --dfs.destroy --dfs.pool $POOL_UUID 
+             -a DFS --dfs.destroy --dfs.pool $POOL_UUID
              --dfs.cont $(uuidgen) --dfs.svcl $POOL_SVC
              -n 500  -u -L --dfs.oclass S1 -N 1 -P -d /"
 
         mpich_cmd="mpirun
-             -np $no_of_ps -map-by node 
+             -np $no_of_ps -map-by node
              -hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
              $mdtest_cmd"
 
-        openmpi_cmd="orterun $OMPI_PARAM 
+        openmpi_cmd="orterun $OMPI_PARAM
              -x CPATH -x PATH -x LD_LIBRARY_PATH
              -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-             --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node 
+             --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node
              --hostfile Log/$SLURM_JOB_ID/daos_client_hostlist
              $mdtest_cmd"
 
@@ -350,7 +351,7 @@ run_mdtest(){
         fi
 
         echo $cmd
-	echo
+       echo
         eval $cmd
         if [ $? -ne 0 ]; then
             echo -e "\nSTATUS: process_per_client=$i - MDTEST FAIL\n"
@@ -368,6 +369,7 @@ test=$1
 
 echo "###################"
 echo "RUN: $TESTCASE"
+echo "Start Time: $(date)"
 echo "###################"
 
 case $test in


### PR DESCRIPTION
Automating 2 ior hard testcases:
- scaling server2client 1to4
- constant client count at 16, scaling server

Codebase enhancements
- Run python linter on run_testlist.py file
- Update get_ior_results.sh file to collec ior results
  into a csv file
- Add a function to wait for all the DAOS servers to
  be up or the function timeout

Signed-off-by: Martinez Montes, Jonathan <jonathan.martinez.montes@intel.com>