### PR TITLE
DAOS-6024 Add stabilization test

### DIFF
--- a/get_ior_results.sh
+++ b/get_ior_results.sh
@@ -24,7 +24,7 @@ result=${RES_DIR}/result_${current}.csv
 # Extract results from test logs
 
 function get_value(){
-    grep -E "^${1}[[:space:]]*:\s" ${2} | cut -d ':' -f 2 | tr -d ' '
+    grep -E "^${1}[[:space:]]*:\s" ${2} | cut -d ':' -f 2 | tr -d ' ' | head -1
 }
 
 echo "Servers,Clients,PPC,Ranks,Scenario,Max Write (GiB/sec),Max Read (GiB/sec),Start,End,Status" > ${result}
@@ -37,7 +37,7 @@ echo "Servers,Clients,PPC,Ranks,Scenario,Max Write (GiB/sec),Max Read (GiB/sec),
 for i in *
 do
     if [ -d "$i" ] && [[ "$i" = log* ]]; then
-        CURRENT_FILE=${RES_DIR}/$i/stdout*
+        CURRENT_FILE=$(find ${RES_DIR}/$i -type f -name "stdout*")
         SERVERS=$(grep -E "^DAOS_SERVERS=" ${CURRENT_FILE} | cut -d '=' -f 2 | tr -d ' ')
         CLIENTS=$(get_value 'nodes' ${CURRENT_FILE})
         RANKS=$(get_value 'tasks' ${CURRENT_FILE})
@@ -46,9 +46,9 @@ do
         START_TIME=$(grep -E "^Start Time:\s" ${CURRENT_FILE} | sed "s/Start Time: //g")
         END_TIME=$(grep -E "^End Time:\s" ${CURRENT_FILE} | sed "s/End Time: //g")
 
-        if [ -f "$i"/stdout* ] && grep -q "Max Write" "$i"/stdout* ; then
-            wr=`grep "Max Write" ./$i/stdout* | awk '{print $3}'`
-            rd=`grep "Max Read" ./$i/stdout* | awk '{print $3}'`
+        if [ -f "${CURRENT_FILE}" ] && grep -q "Max Write" "${CURRENT_FILE}" ; then
+            wr=`grep "Max Write" ${CURRENT_FILE} | awk '{print $3}'`
+            rd=`grep "Max Read" ${CURRENT_FILE} | awk '{print $3}'`
             wr_GiB=`echo "scale=2;$wr / 1024" | bc`
             rd_GiB=`echo "scale=2;$rd / 1024" | bc`
             echo "${SERVERS},${CLIENTS},${PPC},${RANKS},${SCENARIO},${wr_GiB},${rd_GiB},${START_TIME},${END_TIME},Passed" >> ${result}

--- a/get_mdtest_results.sh
+++ b/get_mdtest_results.sh
@@ -38,7 +38,7 @@ echo "Servers,Clients,Ranks,Scenario,create(Kops/sec),stat(Kops/sec),read(Kops/s
 for i in *
 do
     if [ -d "$i" ] && [[ "$i" = log* ]]; then
-        CURRENT_FILE=${RES_DIR}/$i/stdout*
+        CURRENT_FILE=$(find ${RES_DIR}/$i -type f -name "stdout*")
         SERVERS=$(get_value "DAOS_SERVERS=" ${CURRENT_FILE} = 2)
         RANKS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 5)
         CLIENTS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 9)
@@ -46,11 +46,11 @@ do
         START_TIME=$(grep -E "^Start Time:\s" ${CURRENT_FILE} | sed "s/Start Time: //g")
         END_TIME=$(grep -E "^End Time:\s" ${CURRENT_FILE} | sed "s/End Time: //g")
 
-        if [ -f "$i"/stdout* ] && grep -q "SUMMARY rate" "$i"/stdout* ; then
-            cr=`grep -A 11 "SUMMARY rate:" ./$i/stdout* | grep "File creation" | awk '{print $6}'`
-            st=`grep -A 11 "SUMMARY rate:" ./$i/stdout* | grep "File stat" | awk '{print $6}'`
-            rd=`grep -A 11 "SUMMARY rate:" ./$i/stdout* | grep "File read" | awk '{print $6}'`
-            rl=`grep -A 11 "SUMMARY rate:" ./$i/stdout* | grep "File removal" | awk '{print $6}'`
+        if [ -f "${CURRENT_FILE}" ] && grep -q "SUMMARY rate" "${CURRENT_FILE}" ; then
+            cr=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File creation" | awk '{print $6}'`
+            st=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File stat" | awk '{print $6}'`
+            rd=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File read" | awk '{print $6}'`
+            rl=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File removal" | awk '{print $6}'`
 
             cr_Kop=`echo "scale=2;$cr / 1000" | bc`
             st_Kop=`echo "scale=2;$st / 1000" | bc`

--- a/print_node_local_time.sh
+++ b/print_node_local_time.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$(hostname) $(date +%m/%d/%G-%H:%M:%S.%N)"
+

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -141,7 +141,7 @@ mdtest_testlist = [{'testcase': 'mdtesteasy_1to4',
                     }
                    ]
 
-stabilization_testlist = [{'testcase': 'pool_rebuild',
+swim_test = [{'testcase': 'pool_rebuild',
                            'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
                            'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                            # timeout in minutes
@@ -155,9 +155,9 @@ stabilization_testlist = [{'testcase': 'pool_rebuild',
 dst_dir = os.getenv("DST_DIR")
 script = os.path.join(dst_dir, "run_sbatch.sh")
 
-for test in stabilization_testlist:
+for test in swim_test:
     if test['enabled'] == 1:
-        env['TEST_GROUP'] = "STABILIZATION"
+        env['TEST_GROUP'] = "SWIM"
         env['TESTCASE'] = test['testcase']
         for i in range(len(test['nServer'])):
             srv = test['nServer'][i]

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -141,8 +141,49 @@ mdtest_testlist = [{'testcase': 'mdtesteasy_1to4',
                     }
                    ]
 
+stabilization_testlist = [{'testcase': 'pool_rebuild',
+                           'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+                           'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                           # timeout in minutes
+                           'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15, 15],
+                           'ppc': 32,
+                           'pool_sz': '85G',
+                           'enabled': 0
+                           }
+                         ]
+
 dst_dir = os.getenv("DST_DIR")
 script = os.path.join(dst_dir, "run_sbatch.sh")
+
+for test in stabilization_testlist:
+    if test['enabled'] == 1:
+        env['TEST_GROUP'] = "STABILIZATION"
+        env['TESTCASE'] = test['testcase']
+        for i in range(len(test['nServer'])):
+            srv = test['nServer'][i]
+            cli = test['nClient'][i]
+            nodes = srv + cli + 1
+            cores = nodes * test['ppc']
+            if nodes <= 512:
+                env['PARTITION'] = 'normal'
+            else:
+                env['PARTITION'] = 'large'
+
+            env['DAOS_SERVERS'] = str(srv)
+            env['DAOS_CLIENTS'] = str(cli)
+            env['NNODE'] = str(nodes)
+            env['NCORE'] = str(cores)
+            env['PPC'] = str(test['ppc'])
+            env['POOL_SIZE'] = test['pool_sz']
+
+            t = test['timeout'][i] + 10
+            h = int(t / 60)
+            m = t % 60
+            s = 0
+            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
+            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+
+            subprocess.Popen(script, env=env)
 
 for test in slf_testlist:
     if test['enabled'] == 1:

--- a/tests.sh
+++ b/tests.sh
@@ -498,7 +498,6 @@ function run_testcase(){
     case ${test} in
         STABILIZATION)
             start_server
-            start_agent
             create_pool
             kill_random_server
             ;;

--- a/tests.sh
+++ b/tests.sh
@@ -451,6 +451,11 @@ function kill_random_server(){
     local DOOMED_SERVER=$(get_doom_server)
     local MAX_RETRY_ATTEMPTS=30
 
+    pmsg "Retrieving local time of each node"
+    run_cmd "clush --hostfile ${ALL_HOSTLIST_FILE} \
+                   -f ${SLURM_JOB_NUM_NODES} \
+                   ${DST_DIR}/print_node_local_time.sh"
+
     run_cmd "dmg -o ${DAOS_CONTROL_YAML} pool list"
     run_cmd "dmg -o ${DAOS_CONTROL_YAML} pool query --pool ${POOL_UUID}"
     run_cmd "dmg -o ${DAOS_CONTROL_YAML} system query"
@@ -496,7 +501,8 @@ function run_testcase(){
     echo "###################"
 
     case ${test} in
-        STABILIZATION)
+        SWIM)
+            # Swim stabilization test by checking server fault detection
             start_server
             create_pool
             kill_random_server


### PR DESCRIPTION
Automating 1 stabilization testcase
    - Start DAOS with N servers
    - Create a pool
    - Randomly select and kill one server
    - Wait until rebuild is completed

Add the teardown function. This function helps the slurm job
to finish early when the test fails and save compute time on the
cluster. Otherwise, the servers continue running until the slurm
job timeout.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>