### PR TITLE
DAOS-4810: Add ior easy testcases with replication

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,4 +3,4 @@
 rm -rf /dev/shm/*
 rm -rf /tmp/daos*log
 
-mv Log/$SLURM_JOB_ID $LOGS/log_$1
+mv -v Log/$SLURM_JOB_ID $LOGS/log_$1 || true

--- a/copy_log_files.sh
+++ b/copy_log_files.sh
@@ -2,4 +2,4 @@
 
 HOSTNAME=$(hostname)
 TMP="$HOSTNAME"
-cp -rf /tmp/daos*log Log/$SLURM_JOB_ID/$1/$TMP/
+cp -rfv /tmp/daos*log Log/$SLURM_JOB_ID/$1/$TMP/ || true

--- a/daos_server.yml
+++ b/daos_server.yml
@@ -6,7 +6,7 @@ name: daos_server
 nr_hugepages: 4096
 port: 10001
 provider: ofi+verbs;ofi_rxm
-crt_timeout: 300
+crt_timeout: 180
 crt_ctx_share_addr: 0
 servers:
 - env_vars:
@@ -19,6 +19,9 @@ servers:
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
   - OFI_DOMAIN=mlx5_0
+  - FI_MR_CACHE_MAX_COUNT=0
+  - FI_UNIVERSE_SIZE=16383
+  - FI_VERBS_PREFER_XRC=1
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0

--- a/env_daos
+++ b/env_daos
@@ -1,4 +1,6 @@
 export FI_MR_CACHE_MAX_COUNT=0
+export FI_UNIVERSE_SIZE=16383
+export FI_VERBS_PREFER_XRC=1
 export D_LOG_FILE=/tmp/daos_client.log
 export D_LOG_MASK=ERR
 export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"

--- a/get_mdtest_results.sh
+++ b/get_mdtest_results.sh
@@ -16,7 +16,9 @@ cd $RES_DIR
 
 #Test name
 current=${PWD##*/}
-echo $current
+echo
+echo "Test Name: ${current}"
+echo
 
 #Output file
 result=${RES_DIR}/result_${current}.csv
@@ -27,7 +29,47 @@ function get_value(){
     grep -E "^${1}" ${2} | cut -d "${3}" -f ${4} | tr -d ' '
 }
 
-echo "Servers,Clients,Ranks,Scenario,create(Kops/sec),stat(Kops/sec),read(Kops/sec),remove(Kops/sec),creates/sec,stat/sec,reads/sec,remove/sec,Start,End,Status" > $result
+function get_time_stamp(){
+    local LOG_FILE="${1}"
+    local VALUE_LABEL="${2}"
+
+    local TIME=$(grep -E "^${VALUE_LABEL}:\s" ${LOG_FILE} | sed "s/${VALUE_LABEL}:\s//g")
+
+    date -d "${TIME}" +"%m/%d/%Y %H:%M:%S"
+}
+
+function update_csv(){
+    local CURRENT_FILE=${1}
+    local RESULT_FILE=${2}
+
+    echo "  reaing file: ${CURRENT_FILE}"
+
+    SERVERS=$(get_value "DAOS_SERVERS=" ${CURRENT_FILE} = 2)
+    RANKS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 5)
+    CLIENTS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 9)
+    SCENARIO=$(get_value "RUN[[:space:]]*:\s" ${CURRENT_FILE} : 2)
+    START_TIME="$(get_time_stamp ${CURRENT_FILE} "Start Time")"
+    END_TIME="$(get_time_stamp ${CURRENT_FILE} "End Time")"
+
+    if [ -f "${CURRENT_FILE}" ] && grep -q "SUMMARY rate" "${CURRENT_FILE}" ; then
+        cr=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File creation" | awk '{print $6}'`
+        st=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File stat" | awk '{print $6}'`
+        rd=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File read" | awk '{print $6}'`
+        rl=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File removal" | awk '{print $6}'`
+
+        cr_Kop=`echo "scale=2;$cr / 1000" | bc`
+        st_Kop=`echo "scale=2;$st / 1000" | bc`
+        rd_Kop=`echo "scale=2;$rd / 1000" | bc`
+        rm_Kop=`echo "scale=2;$rl / 1000" | bc`
+
+        echo "${SERVERS},${CLIENTS},${RANKS},${SCENARIO},${cr_Kop},${st_Kop},${rd_Kop},${rm_Kop},${cr},${st},${rd},${rl},${START_TIME},${END_TIME},Passed" >> ${RESULT_FILE}
+
+    else
+        echo "${SERVERS},${CLIENTS},${RANKS},${SCENARIO},0,0,0,0,0,0,0,0,${START_TIME},${END_TIME},Failed" >> ${RESULT_FILE}
+    fi
+}
+
+echo "Servers,Clients,Ranks,Scenario,create(Kops/sec),stat(Kops/sec),read(Kops/sec),remove(Kops/sec),creates/sec,stat/sec,reads/sec,remove/sec,Start,End,Status" > ${result}
 
 # For each directory in the curret dir, if the name starts with log
 # get the run configuration parameters
@@ -38,31 +80,18 @@ echo "Servers,Clients,Ranks,Scenario,create(Kops/sec),stat(Kops/sec),read(Kops/s
 for i in *
 do
     if [ -d "$i" ] && [[ "$i" = log* ]]; then
-        CURRENT_FILE=$(find ${RES_DIR}/$i -type f -name "stdout*")
-        SERVERS=$(get_value "DAOS_SERVERS=" ${CURRENT_FILE} = 2)
-        RANKS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 5)
-        CLIENTS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 9)
-        SCENARIO=$(get_value "RUN[[:space:]]*:\s" ${CURRENT_FILE} : 2)
-        START_TIME=$(grep -E "^Start Time:\s" ${CURRENT_FILE} | sed "s/Start Time: //g")
-        END_TIME=$(grep -E "^End Time:\s" ${CURRENT_FILE} | sed "s/End Time: //g")
+        FILES="$(find ${RES_DIR}/$i -type f -name "stdout*")"
 
-        if [ -f "${CURRENT_FILE}" ] && grep -q "SUMMARY rate" "${CURRENT_FILE}" ; then
-            cr=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File creation" | awk '{print $6}'`
-            st=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File stat" | awk '{print $6}'`
-            rd=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File read" | awk '{print $6}'`
-            rl=`grep -A 11 "SUMMARY rate:" ${CURRENT_FILE} | grep "File removal" | awk '{print $6}'`
+        for j in ${FILES}
+        do
+            if [ -z ${j} ]; then
+                continue
+            fi
 
-            cr_Kop=`echo "scale=2;$cr / 1000" | bc`
-            st_Kop=`echo "scale=2;$st / 1000" | bc`
-            rd_Kop=`echo "scale=2;$rd / 1000" | bc`
-            rm_Kop=`echo "scale=2;$rl / 1000" | bc`
-
-            echo "${SERVERS},${CLIENTS},${RANKS},${SCENARIO},${cr_Kop},${st_Kop},${rd_Kop},${rm_Kop},${cr},${st},${rd},${rl},${START_TIME},${END_TIME},Passed" >> $result
-
-        else
-            echo "${SERVERS},${CLIENTS},${RANKS},${SCENARIO},0,0,0,0,0,0,0,0,${START_TIME},${END_TIME},Failed" >> $result
-        fi
+            update_csv ${j} $result
+        done
     fi
 done
 
+echo
 echo " Done.  Results in $result"

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -17,266 +17,424 @@ env['RES_DIR']    = "<path_to_result_dir>" #/home1/06753/soychan/work/POC/TESTS/
 env['MPICH_DIR']  = "<path_to_mpich>" #e.g./scratch/POC/mpich
 env['OPENMPI_DIR']= "<path_to_openmpi>" #e.g./scratch/POC/openmpi
 
-slf_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
-                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],
-                 'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                 'ppc': 1,
-                 'inflight': 1,
-                 'enabled': 0
+
+self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
+                  # Number of servers, number of clients, timeout in minutes
+                  'test_plan': [
+                      (2, 1, 15),
+                      (4, 1, 15),
+                      (8, 1, 15),
+                      (16, 1, 15),
+                      (32, 1, 15),
+                      (64, 1, 15),
+                      (128, 1, 15),
+                      (256, 1, 15),
+                      (512, 1, 15)
+                  ],
+                  'ppc': 1,
+                  'env_vars': {
+                      'inflight': 1
+                  },
+                  'enabled': False
+                  },
+                 {'testcase': 'st_1tomany_cli2srv_inf16',
+                  # Number of servers, number of clients, timeout in minutes
+                  'test_plan': [
+                      (2, 1, 15),
+                      (4, 1, 15),
+                      (8, 1, 15),
+                      (16, 1, 15),
+                      (32, 1, 15),
+                      (64, 1, 15),
+                      (128, 1, 15),
+                      (256, 1, 15),
+                      (512, 1, 15)
+                  ],
+                  'ppc': 1,
+                  'env_vars': {
+                      'inflight': 16
+                  },
+                  'enabled': False
+                  }
+                 ]
+
+ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 8, 15),
+                     (4, 16, 15),
+                     (8, 32, 15),
+                     (16, 64, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'SX'
                  },
-                {'testcase': 'st_1tomany_cli2srv_inf16',
-                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512],
-                 'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                 'ppc': 1,
-                 'inflight': 16,
-                 'enabled': 0
+                 'enabled': False
+                 },
+                {'testcase': 'ior_easy_c16_sx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 16, 15),
+                     (4, 16, 15),
+                     (8, 16, 15),
+                     (16, 16, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'SX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_easy_1to4_2gx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 8, 15),
+                     (4, 16, 15),
+                     (8, 32, 15),
+                     (16, 64, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'RP_2GX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_easy_c16_2gx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 16, 15),
+                     (4, 16, 15),
+                     (8, 16, 15),
+                     (16, 16, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'RP_2GX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_easy_1to4_3gx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (4, 16, 15),
+                     (8, 32, 15),
+                     (16, 64, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'RP_3GX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_easy_c16_3gx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (4, 16, 15),
+                     (8, 16, 15),
+                     (16, 16, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '1',
+                     'xfer_size': '1M',
+                     'block_size': '1G',
+                     'oclass': 'RP_3GX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_hard_1to4_sx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 8, 15),
+                     (4, 16, 15),
+                     (8, 32, 15),
+                     (16, 64, 15),
+                     (32, 128, 20),
+                     (64, 256, 20),
+                     (128, 512, 20),
+                     (256, 1024, 20)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '2000000',
+                     'xfer_size': '47008',
+                     'block_size': '47008',
+                     'oclass': 'SX'
+                 },
+                 'enabled': False
+                 },
+                {'testcase': 'ior_hard_c16_sx',
+                 # Number of servers, number of clients, timeout in minutes
+                 'test_plan': [
+                     (2, 16, 15),
+                     (4, 16, 15),
+                     (8, 16, 15),
+                     (16, 16, 15),
+                     (32, 16, 15),
+                     (64, 16, 15),
+                     (128, 16, 15),
+                     (256, 16, 15)
+                 ],
+                 'ppc': 32,
+                 'env_vars': {
+                     'pool_size': '85G',
+                     'segments': '2000000',
+                     'xfer_size': '47008',
+                     'block_size': '47008',
+                     'oclass': 'SX'
+                 },
+                 'enabled': False
                  }
                 ]
 
-ior_testlist = [{'testcase': 'ioreasy_1to4',
-                 'nServer': [2, 4, 8, 16],
-                 'nClient': [8, 16, 32, 64],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15],
-                 'ppc': 32,
-                 'segments': '1',
-                 'pool_sz': '85G',
-                 'xfer_sz': '1M',
-                 'blk_sz': '1G',
-                 'enabled': 0
-                 },
-                {'testcase': 'ioreasy_c16',
-                 'nServer': [2, 4, 8, 16],
-                 'nClient': [16, 16, 16, 16],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15],
-                 'ppc': 32,
-                 'segments': '1',
-                 'pool_sz': '85G',
-                 'xfer_sz': '1M',
-                 'blk_sz': '1G',
-                 'enabled': 0
-                 },
-                {'testcase': 'iorhard_1to4',
-                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                 'nClient': [8, 16, 32, 64, 128, 256, 512, 1024],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15, 120, 120, 120, 120],
-                 'ppc': 32,
-                 'segments': '2000000',
-                 'pool_sz': '85G',
-                 'xfer_sz': '47008',
-                 'blk_sz': '47008',
-                 'enabled': 0
-                 },
-                {'testcase': 'iorhard_c16',
-                 'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                 'nClient': [16, 16, 16, 16, 16, 16, 16, 16],
-                 # timeout in minutes
-                 'timeout': [15, 15, 15, 15, 15, 15, 15, 15],
-                 'ppc': 32,
-                 'segments': '2000000',
-                 'pool_sz': '85G',
-                 'xfer_sz': '47008',
-                 'blk_sz': '47008',
-                 'enabled': 0
-                 }
-                ]
 
-mdtest_testlist = [{'testcase': 'mdtesteasy_1to4',
-                    'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                    'nClient': [8, 16, 32, 64, 128, 256, 512, 1024],
-                    # timeout in minutes
-                    'timeout': [15, 15, 15, 60, 120, 120, 120, 120],
+mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'test_plan': [
+                        (2, 8, 15),
+                        (4, 16, 15),
+                        (8, 32, 15),
+                        (16, 64, 15),
+                        (32, 128, 15),
+                        (64, 256, 15),
+                        (128, 512, 20),
+                        (256, 1024, 20)
+                    ],
                     'ppc': 32,
-                    'pool_sz': '85G',
-                    'nFile': '12000',
-                    'bytes_read': '0',
-                    'bytes_write': '0',
-                    'tree_depth': '0',
-                    'enabled': 0
+                    'env_vars': {
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '0',
+                        'bytes_write': '0',
+                        'tree_depth': '0',
+                        'dir_oclass': 'S1',
+                        'oclass': 'SX'
                     },
-                   {'testcase': 'mdtesteasy_c16',
-                    'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                    'nClient': [16, 16, 16, 16, 16, 16, 16, 16],
-                    # timeout in minutes
-                    'timeout': [15, 15, 15, 30, 30, 45, 60, 60],
-                    'ppc': 32,
-                    'pool_sz': '85G',
-                    'nFile': '12000',
-                    'bytes_read': '0',
-                    'bytes_write': '0',
-                    'tree_depth': '0',
-                    'enabled': 0
+                    'enabled': False
                     },
-                   {'testcase': 'mdtesthard_1to4',
-                    'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                    'nClient': [8, 16, 32, 64, 128, 256, 512, 1024],
-                    # timeout in minutes
-                    'timeout': [15, 15, 30, 60, 90, 90, 120, 120],
+                   {'testcase': 'mdtest_easy_c16_sx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'test_plan': [
+                        (2, 16, 15),
+                        (4, 16, 15),
+                        (8, 16, 15),
+                        (16, 16, 15),
+                        (32, 16, 15),
+                        (64, 16, 15),
+                        (128, 16, 15),
+                        (256, 16, 15)
+                    ],
                     'ppc': 32,
-                    'pool_sz': '85G',
-                    'nFile': '12000',
-                    'bytes_read': '3901',
-                    'bytes_write': '3901',
-                    'tree_depth': '0/20',
-                    'enabled': 0
+                    'env_vars': {
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '0',
+                        'bytes_write': '0',
+                        'tree_depth': '0',
+                        'dir_oclass': 'S1',
+                        'oclass': 'SX'
                     },
-                   {'testcase': 'mdtesthard_c16',
-                    'nServer': [2, 4, 8, 16, 32, 64, 128, 256],
-                    'nClient': [16, 16, 16, 16, 16, 16, 16, 16],
-                    # timeout in minutes
-                    'timeout': [15, 15, 15, 30, 45, 45, 60, 90],
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_1to4_sx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'test_plan': [
+                        (2, 8, 15),
+                        (4, 16, 15),
+                        (8, 32, 15),
+                        (16, 64, 15),
+                        (32, 128, 15),
+                        (64, 256, 15),
+                        (128, 512, 20),
+                        (256, 1024, 20)
+                    ],
                     'ppc': 32,
-                    'pool_sz': '85G',
-                    'nFile': '12000',
-                    'bytes_read': '3901',
-                    'bytes_write': '3901',
-                    'tree_depth': '0/20',
-                    'enabled': 0
+                    'env_vars': {
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'dir_oclass': 'S1',
+                        'oclass': 'SX'
+                    },
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_c16_sx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'test_plan': [
+                        (2, 16, 15),
+                        (4, 16, 15),
+                        (8, 16, 15),
+                        (16, 16, 15),
+                        (32, 16, 15),
+                        (64, 16, 15),
+                        (128, 16, 15),
+                        (256, 16, 15)
+                    ],
+                    'ppc': 32,
+                    'env_vars': {
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'dir_oclass': 'S1',
+                        'oclass': 'SX'
+                    },
+                    'enabled': False
                     }
                    ]
 
-swim_test = [{'testcase': 'pool_rebuild',
-                           'nServer': [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
-                           'nClient': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-                           # timeout in minutes
-                           'timeout': [15, 15, 15, 15, 15, 15, 15, 15, 15, 15],
-                           'ppc': 32,
-                           'pool_sz': '85G',
-                           'enabled': 0
-                           }
-                         ]
 
-dst_dir = os.getenv("DST_DIR")
-script = os.path.join(dst_dir, "run_sbatch.sh")
+swim_testlist = [{'testcase': 'pool_rebuild',
+                  # Number of servers, number of clients, timeout in minutes
+                  'test_plan': [
+                      (4, 1, 15),
+                      (4, 1, 15),
+                      (8, 1, 15),
+                      (16, 1, 15),
+                      (32, 1, 15),
+                      (64, 1, 15),
+                      (128, 1, 15),
+                      (256, 1, 15),
+                      (512, 1, 15),
+                      (1024, 1, 15)
+                  ],
+                  'ppc': 32,
+                  'env_vars': {
+                      'pool_size': '85G'
+                  },
+                  'enabled': False
+                  }
+                 ]
 
-for test in swim_test:
-    if test['enabled'] == 1:
-        env['TEST_GROUP'] = "SWIM"
+
+class TestList(object):
+    def __init__(self, test_group, testlist, env, script='run_sbatch.sh'):
+        self._test_group = test_group
+        self._testlist = testlist
+        self._env = env
+        self._teardown_offset = 10
+        dst_dir = os.getenv('DST_DIR')
+        self._script = os.path.join(dst_dir, script)
+
+    def _expand_default_env_vars(self, env, test):
+        env['TEST_GROUP'] = self._test_group
         env['TESTCASE'] = test['testcase']
-        for i in range(len(test['nServer'])):
-            srv = test['nServer'][i]
-            cli = test['nClient'][i]
-            nodes = srv + cli + 1
-            cores = nodes * test['ppc']
-            if nodes <= 512:
-                env['PARTITION'] = 'normal'
-            else:
-                env['PARTITION'] = 'large'
+        env['PPC'] = str(test['ppc'])
 
-            env['DAOS_SERVERS'] = str(srv)
-            env['DAOS_CLIENTS'] = str(cli)
-            env['NNODE'] = str(nodes)
-            env['NCORE'] = str(cores)
-            env['PPC'] = str(test['ppc'])
-            env['POOL_SIZE'] = test['pool_sz']
+    def _expand_extra_end_vars(self, env, test):
+        env_vars = test.get('env_vars', {})
+        for name, value in env_vars.items():
+            env[name.upper()] = str(value)
 
-            t = test['timeout'][i] + 10
-            h = int(t / 60)
-            m = t % 60
-            s = 0
-            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+    def _add_partition(self, env, nodes):
+        if nodes <= 512:
+            env['PARTITION'] = 'normal'
+        else:
+            env['PARTITION'] = 'large'
 
-            subprocess.Popen(script, env=env)
+    def _add_timeout(self, env, timeout):
+        h = (timeout + self._teardown_offset) // 60
+        m = (timeout + self._teardown_offset) % 60
+        s = 0
+        env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
+        env['OMPI_TIMEOUT'] = str(timeout * 60)
 
-for test in slf_testlist:
-    if test['enabled'] == 1:
-        env['TEST_GROUP'] = "SELF_TEST"
-        env['TESTCASE'] = test['testcase']
-        env['INFLIGHT'] = str(test['inflight'])
-        for i in range(len(test['nServer'])):
-            srv = test['nServer'][i]
-            cli = test['nClient'][i]
-            nodes = srv + cli + 1
-            cores = nodes * test['ppc']
-            if nodes <= 512:
-                env['PARTITION'] = 'normal'
-            else:
-                env['PARTITION'] = 'large'
+    def _expand_scenario(self, env, ppc, scenario):
+        srv, cli, timeout = scenario
 
-            env['DAOS_SERVERS'] = str(srv)
-            env['DAOS_CLIENTS'] = str(cli)
-            env['NNODE'] = str(nodes)
-            env['NCORE'] = str(cores)
+        nodes = srv + cli + 1
+        cores = nodes * ppc
 
-            t = test['timeout'][i] + 10
-            h = int(t / 60)
-            m = t % 60
-            s = 0
-            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+        env['DAOS_SERVERS'] = str(srv)
+        env['DAOS_CLIENTS'] = str(cli)
+        env['NNODE'] = str(nodes)
+        env['NCORE'] = str(cores)
 
-            subprocess.Popen(script, env=env)
+        self._add_partition(env, nodes)
+        self._add_timeout(env, timeout)
 
-for test in ior_testlist:
-    if test['enabled'] == 1:
-        env['TEST_GROUP'] = "IOR"
-        env['TESTCASE'] = test['testcase']
-        for i in range(len(test['nServer'])):
-            srv = test['nServer'][i]
-            cli = test['nClient'][i]
-            nodes = srv + cli + 1
-            cores = nodes * test['ppc']
-            if nodes <= 512:
-                env['PARTITION'] = 'normal'
-            else:
-                env['PARTITION'] = 'large'
+    def run(self):
+        for test in self._testlist:
+            if not test['enabled']:
+                continue
 
-            env['DAOS_SERVERS'] = str(srv)
-            env['DAOS_CLIENTS'] = str(cli)
-            env['NNODE'] = str(nodes)
-            env['NCORE'] = str(cores)
-            env['PPC'] = str(test['ppc'])
-            env['SEGMENTS'] = test['segments']
-            env['POOL_SIZE'] = test['pool_sz']
-            env['XFER_SIZE'] = test['xfer_sz']
-            env['BLOCK_SIZE'] = test['blk_sz']
+            env = self._env
+            self._expand_default_env_vars(env, test)
+            self._expand_extra_end_vars(env, test)
+            ppc = test['ppc']
+            for scenario in test['test_plan']:
+                self._expand_scenario(env, ppc, scenario)
+                subprocess.Popen(self._script, env=env)
 
-            t = test['timeout'][i] + 10
-            h = int(t / 60)
-            m = t % 60
-            s = 0
-            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
 
-            subprocess.Popen(script, env=env)
+class SelfTestList(TestList):
+    def __init__(self, testlist):
+        super(SelfTestList, self).__init__('SELF_TEST', testlist, env)
 
-for test in mdtest_testlist:
-    if test['enabled'] == 1:
-        env['TEST_GROUP'] = "MDTEST"
-        env['TESTCASE'] = test['testcase']
-        for i in range(len(test['nServer'])):
-            srv = test['nServer'][i]
-            cli = test['nClient'][i]
-            nodes = srv + cli + 1
-            cores = nodes * test['ppc']
-            if nodes <= 512:
-                env['PARTITION'] = 'normal'
-            else:
-                env['PARTITION'] = 'large'
 
-            env['DAOS_SERVERS'] = str(srv)
-            env['DAOS_CLIENTS'] = str(cli)
-            env['NNODE'] = str(nodes)
-            env['NCORE'] = str(cores)
-            env['PPC'] = str(test['ppc'])
-            env['POOL_SIZE'] = test['pool_sz']
-            env['N_FILE'] = test['nFile']
-            env['BYTES_READ'] = test['bytes_read']
-            env['BYTES_WRITE'] = test['bytes_write']
-            env['TREE_DEPTH'] = test['tree_depth']
+class IorTestList(TestList):
+    def __init__(self, testlist):
+        super(IorTestList, self).__init__('IOR', testlist, env)
 
-            t = test['timeout'][i] + 10
-            h = int(t / 60)
-            m = t % 60
-            s = 0
-            env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
-            env['OMPI_TIMEOUT'] = str(test['timeout'][i] * 60)
+    def _add_timeout(self, env, timeout):
+        # ior runs twice, read and write operations are performed separately
+        testcase_timeout = timeout * 2
+        h = (testcase_timeout + self._teardown_offset) // 60
+        m = (testcase_timeout + self._teardown_offset) % 60
+        s = 0
+        env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
+        env['OMPI_TIMEOUT'] = str(timeout * 60)
 
-            subprocess.Popen(script, env=env)
+
+class MdtestTestList(TestList):
+    def __init__(self, testlist):
+        super(MdtestTestList, self).__init__('MDTEST', testlist, env)
+
+
+class SwimTestList(TestList):
+    def __init__(self, testlist):
+        super(SwimTestList, self).__init__('SWIM', testlist, env)
+
+
+def main():
+    self_test = SelfTestList(self_testlist)
+    self_test.run()
+
+    ior_test = IorTestList(ior_testlist)
+    ior_test.run()
+
+    mdtest_test = MdtestTestList(mdtest_testlist)
+    mdtest_test.run()
+
+    swim_test = SwimTestList(swim_testlist)
+    swim_test.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -20,7 +20,7 @@ env['OPENMPI_DIR']= "<path_to_openmpi>" #e.g./scratch/POC/openmpi
 
 self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                   # Number of servers, number of clients, timeout in minutes
-                  'testlist': [
+                  'testvariants': [
                       (2, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -39,7 +39,7 @@ self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                   },
                  {'testcase': 'st_1tomany_cli2srv_inf16',
                   # Number of servers, number of clients, timeout in minutes
-                  'testlist': [
+                  'testvariants': [
                       (2, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -60,7 +60,7 @@ self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
 
 ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -78,7 +78,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -96,7 +96,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_1to4_2gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -114,7 +114,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_2gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -132,7 +132,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_1to4_3gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (4, 16, 15),
                      (8, 32, 15),
                      (16, 64, 15)
@@ -149,7 +149,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_3gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (4, 16, 15),
                      (8, 16, 15),
                      (16, 16, 15)
@@ -166,7 +166,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_hard_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -188,7 +188,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_hard_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'testlist': [
+                 'testvariants': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -213,7 +213,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
 
 mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'testlist': [
+                    'testvariants': [
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -237,7 +237,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_easy_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'testlist': [
+                    'testvariants': [
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -261,7 +261,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_hard_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'testlist': [
+                    'testvariants': [
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -285,7 +285,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_hard_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'testlist': [
+                    'testvariants': [
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -312,7 +312,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
 
 swim_testlist = [{'testcase': 'pool_rebuild',
                   # Number of servers, number of clients, timeout in minutes
-                  'testlist': [
+                  'testvariants': [
                       (4, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -365,8 +365,8 @@ class TestList(object):
         env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
         env['OMPI_TIMEOUT'] = str(timeout * 60)
 
-    def _expand_testcase(self, env, ppc, testcase):
-        srv, cli, timeout = testcase
+    def _expand_variant(self, env, ppc, variant):
+        srv, cli, timeout = variant
 
         nodes = srv + cli + 1
         cores = nodes * ppc
@@ -388,8 +388,8 @@ class TestList(object):
             self._expand_default_env_vars(env, test)
             self._expand_extra_env_vars(env, test)
             ppc = test['ppc']
-            for testcase in test['testlist']:
-                self._expand_testcase(env, ppc, testcase)
+            for variant in test['testvariants']:
+                self._expand_variant(env, ppc, variant)
                 subprocess.Popen(self._script, env=env)
 
 

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -20,7 +20,7 @@ env['OPENMPI_DIR']= "<path_to_openmpi>" #e.g./scratch/POC/openmpi
 
 self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                   # Number of servers, number of clients, timeout in minutes
-                  'test_plan': [
+                  'testlist': [
                       (2, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -39,7 +39,7 @@ self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
                   },
                  {'testcase': 'st_1tomany_cli2srv_inf16',
                   # Number of servers, number of clients, timeout in minutes
-                  'test_plan': [
+                  'testlist': [
                       (2, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -60,7 +60,7 @@ self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
 
 ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -78,7 +78,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -96,7 +96,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_1to4_2gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -114,7 +114,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_2gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -132,7 +132,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_1to4_3gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (4, 16, 15),
                      (8, 32, 15),
                      (16, 64, 15)
@@ -149,7 +149,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_easy_c16_3gx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (4, 16, 15),
                      (8, 16, 15),
                      (16, 16, 15)
@@ -166,7 +166,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_hard_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -188,7 +188,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  },
                 {'testcase': 'ior_hard_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
-                 'test_plan': [
+                 'testlist': [
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -213,7 +213,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
 
 mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'test_plan': [
+                    'testlist': [
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -237,7 +237,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_easy_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'test_plan': [
+                    'testlist': [
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -261,7 +261,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_hard_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'test_plan': [
+                    'testlist': [
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -285,7 +285,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     },
                    {'testcase': 'mdtest_hard_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
-                    'test_plan': [
+                    'testlist': [
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -312,7 +312,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
 
 swim_testlist = [{'testcase': 'pool_rebuild',
                   # Number of servers, number of clients, timeout in minutes
-                  'test_plan': [
+                  'testlist': [
                       (4, 1, 15),
                       (4, 1, 15),
                       (8, 1, 15),
@@ -347,7 +347,7 @@ class TestList(object):
         env['TESTCASE'] = test['testcase']
         env['PPC'] = str(test['ppc'])
 
-    def _expand_extra_end_vars(self, env, test):
+    def _expand_extra_env_vars(self, env, test):
         env_vars = test.get('env_vars', {})
         for name, value in env_vars.items():
             env[name.upper()] = str(value)
@@ -365,8 +365,8 @@ class TestList(object):
         env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
         env['OMPI_TIMEOUT'] = str(timeout * 60)
 
-    def _expand_scenario(self, env, ppc, scenario):
-        srv, cli, timeout = scenario
+    def _expand_testcase(self, env, ppc, testcase):
+        srv, cli, timeout = testcase
 
         nodes = srv + cli + 1
         cores = nodes * ppc
@@ -386,10 +386,10 @@ class TestList(object):
 
             env = self._env
             self._expand_default_env_vars(env, test)
-            self._expand_extra_end_vars(env, test)
+            self._expand_extra_env_vars(env, test)
             ppc = test['ppc']
-            for scenario in test['test_plan']:
-                self._expand_scenario(env, ppc, scenario)
+            for testcase in test['testlist']:
+                self._expand_testcase(env, ppc, testcase)
                 subprocess.Popen(self._script, env=env)
 
 


### PR DESCRIPTION
* Add support to collect multiple data points from the
  same build into the csv files.
* Save the repo information into a dedicated file.
* Refactor the run_testlist.py file.
* Kill all the child processes created by the testcase after
  performing the teardown. This allow us to release the
  slurm reservation as soon as the teardown function is
  invocated, and the logs from all the nodes are saved.
* Add the ior easy-1to4 and easy-c16 testcases with
  2-way and 3-way replication.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>