### PR TITLE
Minor fixes and enhancements

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -2,5 +2,3 @@
 
 rm -rf /dev/shm/*
 rm -rf /tmp/daos*log
-
-mv -v Log/$SLURM_JOB_ID $LOGS/log_$1 || true

--- a/copy_log_files.sh
+++ b/copy_log_files.sh
@@ -2,4 +2,4 @@
 
 HOSTNAME=$(hostname)
 TMP="$HOSTNAME"
-cp -rfv /tmp/daos*log Log/$SLURM_JOB_ID/$1/$TMP/ || true
+cp -rfv /tmp/daos*log* ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}/ || true

--- a/create_log_dir.sh
+++ b/create_log_dir.sh
@@ -2,4 +2,4 @@
 
 HOSTNAME=$(hostname)
 TMP="$HOSTNAME"
-mkdir -p Log/$SLURM_JOB_ID/$1/$TMP
+mkdir -p ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}

--- a/daos_server.yml
+++ b/daos_server.yml
@@ -18,7 +18,7 @@ servers:
   - DD_MASK=mgmt,io,md,epc,rebuild
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
-  - OFI_DOMAIN=mlx5_0
+  - OFI_DOMAIN=mlx5_0-xrc
   - FI_MR_CACHE_MAX_COUNT=0
   - FI_UNIVERSE_SIZE=16383
   - FI_VERBS_PREFER_XRC=1

--- a/env_daos
+++ b/env_daos
@@ -5,14 +5,14 @@ export D_LOG_FILE=/tmp/daos_client.log
 export D_LOG_MASK=ERR
 export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
 export OFI_INTERFACE=ib0
-export OFI_DOMAIN=mlx5_0
+export OFI_DOMAIN=mlx5_0-xrc
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
 
 LOCATION=$1
 
 daospath=/$LOCATION/install
-prereqpath=/$LOCATION/install/prereq/dev
+prereqpath=/$LOCATION/install/prereq/release
 
 PATH=${prereqpath}/argobots/bin:$PATH
 PATH=${prereqpath}/isal/bin:$PATH

--- a/mpich_gen_hostlist.sh
+++ b/mpich_gen_hostlist.sh
@@ -3,6 +3,6 @@
 N_SERVERS=$1
 N_CLIENTS=$2
 
-srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" | cut -c 1-8 > Log/$SLURM_JOB_ID/daos_all_hostlist
-cat Log/$SLURM_JOB_ID/daos_all_hostlist | tail -$N_SERVERS > Log/$SLURM_JOB_ID/daos_server_hostlist
-cat Log/$SLURM_JOB_ID/daos_all_hostlist | head -$N_CLIENTS > Log/$SLURM_JOB_ID/daos_client_hostlist
+srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" | cut -c 1-8 > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/openmpi_gen_hostlist.sh
+++ b/openmpi_gen_hostlist.sh
@@ -3,7 +3,7 @@
 N_SERVERS=$1
 N_CLIENTS=$2
 
-srun -n $SLURM_JOB_NUM_NODES hostname > Log/$SLURM_JOB_ID/daos_all_hostlist
+srun -n $SLURM_JOB_NUM_NODES hostname > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
 sed -i "/$(hostname)/d" Log/$SLURM_JOB_ID/daos_all_hostlist
-cat Log/$SLURM_JOB_ID/daos_all_hostlist | tail -$N_SERVERS > Log/$SLURM_JOB_ID/daos_server_hostlist
-cat Log/$SLURM_JOB_ID/daos_all_hostlist | head -$N_CLIENTS > Log/$SLURM_JOB_ID/daos_client_hostlist
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/run_build.sh
+++ b/run_build.sh
@@ -29,7 +29,7 @@ declare -a PRECIOUS_FILES=("bin/daos"
 # List of development or test branches to be merged on top of DAOS
 # master branch
 declare -a DAOS_PATCHES=("origin/tanabarr/control-no-ipmctl-May2020"
-                         "origin/mjmac/allow-fwd-disable-20200508"
+                         "origin/mjmac/io500-frontera"
                          )
 
 function merge_extra_daos_branches() {
@@ -94,7 +94,7 @@ git submodule init
 git submodule update
 print_repo_info |& tee -a ${BUILD_DIR}/latest/repo_info.txt
 merge_extra_daos_branches |& tee -a ${BUILD_DIR}/latest/repo_info.txt
-scons MPI_PKG=any --build-deps=yes --config=force install
+scons MPI_PKG=any --build-deps=yes --config=force BUILD_TYPE=release install
 popd
 popd
 popd
@@ -107,7 +107,7 @@ print_repo_info |& tee -a ${BUILD_DIR}/latest/repo_info.txt
 ./configure --prefix=${LATEST_DAOS}/ior${MPI_SUFFIX} \
             MPICC=${MPI_BIN}/mpicc \
             --with-daos=${LATEST_DAOS} \
-            CPPFLAGS=-I${LATEST_DAOS}/prereq/dev/mercury/include \
+            CPPFLAGS=-I${LATEST_DAOS}/prereq/release/mercury/include \
             LIBS=-lmpi
 make clean
 make

--- a/run_sbatch.sh
+++ b/run_sbatch.sh
@@ -6,7 +6,8 @@ export EMAIL
 export DAOS_DIR
 export TESTCASE
 export LOGS=$RES_DIR/$(date +%Y%m%d)/$TESTCASE
-mkdir -p $LOGS
+export RUN_DIR=${LOGS}/log_${DAOS_SERVERS}
+mkdir -p ${RUN_DIR}
 
 export DAOS_SERVERS
 export DAOS_CLIENTS
@@ -16,7 +17,7 @@ export BLOCK_SIZE
 export PPC
 export OMPI_TIMEOUT
 
-pushd $DST_DIR
+pushd ${RUN_DIR}
 
 echo Running $TESTCASE
-sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION tests.sh $TEST_GROUP
+sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION ${DST_DIR}/tests.sh $TEST_GROUP

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -523,6 +523,8 @@ class TestList(object):
         self._testlist = testlist
         self._env = env
         self._teardown_offset = 10
+        self._pool_create_timeout = 5
+        self._cmd_timeout = 2
         dst_dir = os.getenv('DST_DIR')
         self._script = os.path.join(dst_dir, script)
 
@@ -548,6 +550,8 @@ class TestList(object):
         s = 0
         env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
         env['OMPI_TIMEOUT'] = str(timeout * 60)
+        env['POOL_CREATE_TIMEOUT'] = str(self._pool_create_timeout * 60)
+        env['CMD_TIMEOUT'] = str(self._cmd_timeout * 60)
 
     def _expand_variant(self, env, ppc, variant):
         srv, cli, timeout = variant
@@ -594,6 +598,8 @@ class IorTestList(TestList):
         s = 0
         env['TIMEOUT'] = str(h) + ":" + str(m) + ":" + str(s)
         env['OMPI_TIMEOUT'] = str(timeout * 60)
+        env['POOL_CREATE_TIMEOUT'] = str(self._pool_create_timeout * 60)
+        env['CMD_TIMEOUT'] = str(self._cmd_timeout * 60)
 
 
 class MdtestTestList(TestList):


### PR DESCRIPTION
* Use DAOS release build.
* Update the workaround to run DAOS on Frontera.
* Run DAOS on the target directory rather than running it on
   a temporary directory and then moving/copy results.
* Add timeout option to run commands.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>