### PR TITLE
DAOS-6392: Fix container creation issue

### DIFF
--- a/copy_log_files.sh
+++ b/copy_log_files.sh
@@ -3,3 +3,4 @@
 HOSTNAME=$(hostname)
 TMP="$HOSTNAME"
 cp -rfv /tmp/daos*log* ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}/ || true
+dmesg > ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}/dmesg_output.txt

--- a/openmpi_gen_hostlist.sh
+++ b/openmpi_gen_hostlist.sh
@@ -4,6 +4,6 @@ N_SERVERS=$1
 N_CLIENTS=$2
 
 srun -n $SLURM_JOB_NUM_NODES hostname > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
-sed -i "/$(hostname)/d" Log/$SLURM_JOB_ID/daos_all_hostlist
+sed -i "/$(hostname)/d" ${RUN_DIR}/$SLURM_JOB_ID/daos_all_hostlist
 cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
 cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/tests.sh
+++ b/tests.sh
@@ -254,6 +254,10 @@ create_container(){
     export CPATH=$CPATH; export DAOS_DISABLE_REQ_FWD=1;
     export DAOS_AGENT_DRPC_DIR=$DAOS_AGENT_DRPC_DIR;
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
+    export OFI_DOMAIN=${OFI_DOMAIN}; export OFI_INTERFACE=${OFI_INTERFACE};
+    export FI_MR_CACHE_MAX_COUNT=${FI_MR_CACHE_MAX_COUNT};
+    export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
+    export FI_VERBS_PREFER_XRC=${FI_VERBS_PREFER_XRC};
     $daos_cmd\""
 
     echo $daos_cmd
@@ -272,6 +276,10 @@ create_container(){
     export CPATH=$CPATH; export DAOS_DISABLE_REQ_FWD=1;
     export DAOS_AGENT_DRPC_DIR=$DAOS_AGENT_DRPC_DIR;
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
+    export OFI_DOMAIN=${OFI_DOMAIN}; export OFI_INTERFACE=${OFI_INTERFACE};
+    export FI_MR_CACHE_MAX_COUNT=${FI_MR_CACHE_MAX_COUNT};
+    export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
+    export FI_VERBS_PREFER_XRC=${FI_VERBS_PREFER_XRC};
     $daos_cmd\""
 
     echo $daos_cmd


### PR DESCRIPTION
Re export new/missing env vars in the clush call to daos(8)
There was an incorrect path while creating the hostlist file

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>