### PR TITLE
Miscellaneous fixes and enhancements

### DIFF
--- a/daos_server.yml
+++ b/daos_server.yml
@@ -1,6 +1,6 @@
 access_points: ['replace_this_server:10001']
 control_log_file: /tmp/daos_control.log
-control_log_mask: DEBUG
+control_log_mask: ERROR
 helper_log_file: /tmp/daos_admin.log
 name: daos_server
 nr_hugepages: 4096
@@ -18,10 +18,11 @@ servers:
   - DD_MASK=mgmt,io,md,epc,rebuild
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
-  - OFI_DOMAIN=mlx5_0-xrc
+  - OFI_DOMAIN=mlx5_0
   - FI_MR_CACHE_MAX_COUNT=0
   - FI_UNIVERSE_SIZE=16383
   - FI_VERBS_PREFER_XRC=1
+  - FI_OFI_RXM_USE_SRX=1
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0

--- a/env_daos
+++ b/env_daos
@@ -1,11 +1,12 @@
 export FI_MR_CACHE_MAX_COUNT=0
 export FI_UNIVERSE_SIZE=16383
 export FI_VERBS_PREFER_XRC=1
+export FI_OFI_RXM_USE_SRX=1
 export D_LOG_FILE=/tmp/daos_client.log
 export D_LOG_MASK=ERR
 export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
 export OFI_INTERFACE=ib0
-export OFI_DOMAIN=mlx5_0-xrc
+export OFI_DOMAIN=mlx5_0
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
 

--- a/run_sbatch.sh
+++ b/run_sbatch.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+TIMESTAMP=$(date +%Y%m%d)
+
 export PATH
 export LD_LIBRARY_PATH
 export EMAIL
 export DAOS_DIR
 export TESTCASE
-export LOGS=$RES_DIR/$(date +%Y%m%d)/$TESTCASE
+export LOGS=${RES_DIR}/${TIMESTAMP}/${TESTCASE}
 export RUN_DIR=${LOGS}/log_${DAOS_SERVERS}
 mkdir -p ${RUN_DIR}
 
@@ -19,5 +21,11 @@ export OMPI_TIMEOUT
 
 pushd ${RUN_DIR}
 
-echo Running $TESTCASE
-sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION ${DST_DIR}/tests.sh $TEST_GROUP
+# Get TACC usage status
+/usr/local/etc/taccinfo > ${RUN_DIR}/tacc_usage_status.txt 2>&1
+
+SLURM_JOB="$(sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION ${DST_DIR}/tests.sh $TEST_GROUP)"
+
+echo "$(printf '%80s\n' | tr ' ' =)
+Running ${TESTCASE} with ${DAOS_SERVERS} servers and ${DAOS_CLIENTS} clients
+${SLURM_JOB}" |& tee -a ${RES_DIR}/${TIMESTAMP}/job_list.txt

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -61,13 +61,19 @@ self_testlist = [{'testcase': 'st_1tomany_cli2srv_inf1',
 ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
+                     (1, 4, 15),
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
-                     (16, 64, 15)
+                     (16, 64, 15),
+                     (32, 128, 20),
+                     (64, 256, 20),
+                     (128, 512, 20),
+                     (256, 1024, 20)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -79,13 +85,19 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                 {'testcase': 'ior_easy_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
+                     (1, 16, 15),
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
-                     (16, 16, 15)
+                     (16, 16, 15),
+                     (32, 16, 15),
+                     (64, 16, 15),
+                     (128, 16, 15),
+                     (256, 16, 15)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -100,10 +112,15 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
-                     (16, 64, 15)
+                     (16, 64, 15),
+                     (32, 128, 20),
+                     (64, 256, 20),
+                     (128, 512, 20),
+                     (256, 1024, 20)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -118,10 +135,15 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
-                     (16, 16, 15)
+                     (16, 16, 15),
+                     (32, 16, 15),
+                     (64, 16, 15),
+                     (128, 16, 15),
+                     (256, 16, 15)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -135,10 +157,15 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  'testvariants': [
                      (4, 16, 15),
                      (8, 32, 15),
-                     (16, 64, 15)
+                     (16, 64, 15),
+                     (32, 128, 20),
+                     (64, 256, 20),
+                     (128, 512, 20),
+                     (256, 1024, 20)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -152,10 +179,15 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  'testvariants': [
                      (4, 16, 15),
                      (8, 16, 15),
-                     (16, 16, 15)
+                     (16, 16, 15),
+                     (32, 16, 15),
+                     (64, 16, 15),
+                     (128, 16, 15),
+                     (256, 16, 15)
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
@@ -167,6 +199,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                 {'testcase': 'ior_hard_1to4_sx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
+                     (1, 4, 15),
                      (2, 8, 15),
                      (4, 16, 15),
                      (8, 32, 15),
@@ -178,6 +211,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -189,6 +223,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                 {'testcase': 'ior_hard_c16_sx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
+                     (1, 16, 15),
                      (2, 16, 15),
                      (4, 16, 15),
                      (8, 16, 15),
@@ -200,6 +235,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -222,6 +258,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -244,6 +281,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -266,6 +304,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -288,6 +327,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                  ],
                  'ppc': 32,
                  'env_vars': {
+                     'chunk_size': '1048576',
                      'pool_size': '85G',
                      'segments': '2000000',
                      'xfer_size': '47008',
@@ -302,6 +342,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
 mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
+                        (1, 4, 15),
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -313,12 +354,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'SX'
                     },
                     'enabled': False
@@ -326,6 +367,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                    {'testcase': 'mdtest_easy_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
+                        (1, 16, 15),
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -337,12 +379,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'SX'
                     },
                     'enabled': False
@@ -361,12 +403,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'RP_2GX'
                     },
                     'enabled': False
@@ -385,12 +427,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'RP_2GX'
                     },
                     'enabled': False
@@ -409,12 +451,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'RP_3GX'
                     },
                     'enabled': False
@@ -433,12 +475,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '0',
                         'bytes_write': '0',
                         'tree_depth': '0',
-                        'dir_oclass': 'S1',
                         'oclass': 'RP_3GX'
                     },
                     'enabled': False
@@ -446,6 +488,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                    {'testcase': 'mdtest_hard_1to4_sx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
+                        (1, 4, 15),
                         (2, 8, 15),
                         (4, 16, 15),
                         (8, 32, 15),
@@ -457,12 +500,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '3901',
                         'bytes_write': '3901',
                         'tree_depth': '0/20',
-                        'dir_oclass': 'S1',
                         'oclass': 'SX'
                     },
                     'enabled': False
@@ -470,6 +513,7 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                    {'testcase': 'mdtest_hard_c16_sx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
+                        (1, 16, 15),
                         (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
@@ -481,12 +525,12 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                     ],
                     'ppc': 32,
                     'env_vars': {
+                        'chunk_size': '1048576',
                         'pool_size': '85G',
                         'n_file': '12000',
                         'bytes_read': '3901',
                         'bytes_write': '3901',
                         'tree_depth': '0/20',
-                        'dir_oclass': 'S1',
                         'oclass': 'SX'
                     },
                     'enabled': False


### PR DESCRIPTION
* Enable FI_OFI_RXM_USE_SRX=1 in environment
* Increase ior-easy testvariants
* Build ior from upstream ior repo
* Store current TACC usage
* Run daos_agent only on client nodes
* Run dmg and daos tools from client nodes
* Remove dated --dfs.svcl flag
* Add --dfs.chunk_size flag

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>