### PR TITLE
DAOS-6908: Build DAOS on a compute node

### DIFF
--- a/daos_server.yml
+++ b/daos_server.yml
@@ -8,7 +8,7 @@ port: 10001
 provider: ofi+verbs;ofi_rxm
 crt_timeout: 180
 crt_ctx_share_addr: 0
-servers:
+engines:
 - env_vars:
   - ABT_ENV_MAX_NUM_XSTREAMS=100
   - ABT_MAX_NUM_XSTREAMS=100

--- a/run_build.sh
+++ b/run_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+EXTRA_BUILD="${1}"
+
 export BUILD_DIR="<path_build_area>" #e.g./scratch/POC/BUILDS/
 export MPICH_DIR="<path_to_mpich>" #e.g./scratch/POC/mpich
 export OPENMPI_DIR="<path_to_openmpi>" #e.g./scratch/POC/openmpi
@@ -93,7 +95,7 @@ git submodule init
 git submodule update
 print_repo_info |& tee -a ${BUILD_DIR}/${TIMESTAMP}/repo_info.txt
 merge_extra_daos_branches |& tee -a ${BUILD_DIR}/${TIMESTAMP}/repo_info.txt
-scons MPI_PKG=any --build-deps=yes --config=force BUILD_TYPE=release install
+scons MPI_PKG=any --build-deps=yes --config=force BUILD_TYPE=release install ${EXTRA_BUILD}
 popd
 popd
 popd

--- a/run_build_on_compute_node.sh
+++ b/run_build_on_compute_node.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+JOBNAME="<sbatch_jobname>"
+EMAIL="<email>" #<first.last@email.com>
+export BUILD_DIR="<path_build_area>" #e.g./scratch/POC/BUILDS/
+export DST_DIR="<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
+
+mkdir -p ${BUILD_DIR}/slurm_logs
+pushd ${BUILD_DIR}/slurm_logs
+sbatch -J ${JOBNAME} -t 01:00:00 --mail-user=${EMAIL} -N 1 -n 32 -p normal ${DST_DIR}/run_build_sbatch.sh
+popd
+

--- a/run_build_sbatch.sh
+++ b/run_build_sbatch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#SBATCH -o stdout.o%j           # Name of stdout output file
+#SBATCH -e stderr.e%j           # Name of stderr error file
+#SBATCH -A STAR-Intel           # Project Name
+#SBATCH --mail-type=all         # Send email at begin and end of job
+
+${DST_DIR}/run_build.sh "-j32" |& tee build_output_${SLURM_JOB_ID}.txt


### PR DESCRIPTION
* Propagate environment variables while running commands
  with clush.
* Add script to build DAOS on a compute node.

Signed-off-by: Martinez Montes, Jonathan <jonathan.martinez.montes@intel.com>