### PR TITLE
DAOS-6969: Add function to collect DAOS metrics

### DIFF
--- a/copy_log_files.sh
+++ b/copy_log_files.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
-HOSTNAME=$(hostname)
-TMP="$HOSTNAME"
-dmesg > ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}/dmesg_output.txt
+NODE_TYPE="${1}"
+LOG_DIR=${RUN_DIR}/${SLURM_JOB_ID}/logs/$(hostname)
+
+echo "Copying logs from node $(hostname)"
+
+case ${NODE_TYPE} in
+    server)
+    timeout --signal SIGKILL 1m daos_metrics -i 1 > ${LOG_DIR}/metrics.txt 2>&1
+    timeout --signal SIGKILL 1m dmesg > ${LOG_DIR}/dmesg_output.txt 2>&1
+    ;;
+
+    client)
+    timeout --signal SIGKILL 1m dmesg > ${LOG_DIR}/dmesg_output.txt 2>&1
+    ;;
+
+    *)
+    echo "Error: Invalid node type: ${NODE_TYPE}"
+    exit 1
+    ;;
+esac

--- a/create_log_dir.sh
+++ b/create_log_dir.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-HOSTNAME=$(hostname)
-TMP="$HOSTNAME"
-mkdir -p ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP}
+LOG_DIR=${RUN_DIR}/${SLURM_JOB_ID}/logs/$(hostname)
+
+mkdir -p ${LOG_DIR}
 
 pushd /tmp
 rm -f daos_logs
-ln -s ${RUN_DIR}/${SLURM_JOB_ID}/$1/${TMP} daos_logs
+ln -s ${LOG_DIR} daos_logs
 popd

--- a/daos_server.yml
+++ b/daos_server.yml
@@ -1,6 +1,6 @@
 access_points: ['replace_this_server:10001']
 control_log_file: /tmp/daos_logs/daos_control.log
-control_log_mask: ERROR
+control_log_mask: INFO
 helper_log_file: /tmp/daos_logs/daos_admin.log
 name: daos_server
 nr_hugepages: 4096

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -293,7 +293,6 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                 {'testcase': 'ior_hard_1to4_3gx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
-                     (2, 8, 5),
                      (4, 16, 5),
                      (8, 32, 5),
                      (16, 64, 5),
@@ -316,7 +315,6 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                 {'testcase': 'ior_hard_c16_3gx',
                  # Number of servers, number of clients, timeout in minutes
                  'testvariants': [
-                     (2, 16, 5),
                      (4, 16, 5),
                      (8, 16, 5),
                      (16, 16, 5),
@@ -440,7 +438,6 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                    {'testcase': 'mdtest_easy_1to4_3gx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
-                        (2, 8, 5),
                         (4, 16, 5),
                         (8, 32, 5),
                         (16, 64, 5),
@@ -464,7 +461,6 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                    {'testcase': 'mdtest_easy_c16_3gx',
                     # Number of servers, number of clients, timeout in minutes
                     'testvariants': [
-                        (2, 16, 15),
                         (4, 16, 15),
                         (8, 16, 15),
                         (16, 16, 15),
@@ -532,6 +528,100 @@ mdtest_testlist = [{'testcase': 'mdtest_easy_1to4_sx',
                         'bytes_write': '3901',
                         'tree_depth': '0/20',
                         'oclass': 'S1'
+                    },
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_1to4_2gx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'testvariants': [
+                        (2, 8, 5),
+                        (4, 16, 5),
+                        (8, 32, 5),
+                        (16, 64, 5),
+                        (32, 128, 5),
+                        (64, 256, 5),
+                        (128, 512, 5),
+                        (256, 1024, 5)
+                    ],
+                    'ppc': 32,
+                    'env_vars': {
+                        'chunk_size': '1048576',
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'oclass': 'RP_2GX'
+                    },
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_c16_2gx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'testvariants': [
+                        (2, 16, 5),
+                        (4, 16, 5),
+                        (8, 16, 5),
+                        (16, 16, 5),
+                        (32, 16, 5),
+                        (64, 16, 5),
+                        (128, 16, 5),
+                        (256, 16, 5)
+                    ],
+                    'ppc': 32,
+                    'env_vars': {
+                        'chunk_size': '1048576',
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'oclass': 'RP_2GX'
+                    },
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_1to4_3gx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'testvariants': [
+                        (4, 16, 5),
+                        (8, 32, 5),
+                        (16, 64, 5),
+                        (32, 128, 5),
+                        (64, 256, 5),
+                        (128, 512, 5),
+                        (256, 1024, 5)
+                    ],
+                    'ppc': 32,
+                    'env_vars': {
+                        'chunk_size': '1048576',
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'oclass': 'RP_3GX'
+                    },
+                    'enabled': False
+                    },
+                   {'testcase': 'mdtest_hard_c16_3gx',
+                    # Number of servers, number of clients, timeout in minutes
+                    'testvariants': [
+                        (4, 16, 5),
+                        (8, 16, 5),
+                        (16, 16, 5),
+                        (32, 16, 5),
+                        (64, 16, 5),
+                        (128, 16, 5),
+                        (256, 16, 5)
+                    ],
+                    'ppc': 32,
+                    'env_vars': {
+                        'chunk_size': '1048576',
+                        'pool_size': '85G',
+                        'n_file': '12000',
+                        'bytes_read': '3901',
+                        'bytes_write': '3901',
+                        'tree_depth': '0/20',
+                        'oclass': 'RP_3GX'
                     },
                     'enabled': False
                     }

--- a/tests.sh
+++ b/tests.sh
@@ -31,6 +31,7 @@ DAOS_CONTROL_YAML="${RUN_DIR}/${SLURM_JOB_ID}/daos_control.yml"
 SERVER_HOSTLIST_FILE="${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist"
 ALL_HOSTLIST_FILE="${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist"
 CLIENT_HOSTLIST_FILE="${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist"
+DUMP_DIR="${RUN_DIR}/${SLURM_JOB_ID}/core_dumps"
 INITIAL_BRINGUP_WAIT_TIME=60s
 WAIT_TIME=30s
 MAX_RETRY_ATTEMPTS=6
@@ -241,6 +242,7 @@ function wait_for_servers_to_start(){
 function prepare(){
     #Create the folder for server/client logs.
     mkdir -p ${RUN_DIR}/${SLURM_JOB_ID}
+    mkdir -p ${DUMP_DIR}/{server,ior,mdtest,agent,self_test}
     cp -v ${DST_DIR}/daos_*.yml ${RUN_DIR}/${SLURM_JOB_ID}
     ${SRUN_CMD} ${DST_DIR}/create_log_dir.sh
 
@@ -267,7 +269,7 @@ function start_agent(){
     daos_cmd="daos_agent -o $DAOS_AGENT_YAML -s /tmp/daos_agent"
     cmd="clush --hostfile ${CLIENT_HOSTLIST_FILE}
     -f ${SLURM_JOB_NUM_NODES} \"
-    pushd ${RUN_DIR};
+    pushd ${DUMP_DIR}/agent;
     ulimit -c unlimited;
     export PATH=${PATH};
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH};
@@ -402,7 +404,7 @@ function start_server(){
     daos_cmd="daos_server start -i -o $DAOS_SERVER_YAML --recreate-superblocks"
     cmd="clush --hostfile ${SERVER_HOSTLIST_FILE}
     -f $SLURM_JOB_NUM_NODES \"
-    pushd ${RUN_DIR};
+    pushd ${DUMP_DIR}/server;
     ulimit -c unlimited;
     export PATH=${PATH}; export LD_LIBRARY_PATH=${LD_LIBRARY_PATH};
     export CPATH=${CPATH};
@@ -470,7 +472,7 @@ function run_ior(){
     echo
 
     # Enable core dump creation
-    pushd ${RUN_DIR}
+    pushd ${DUMP_DIR}/ior
     ulimit -c unlimited
     eval $cmd
     IOR_RC=$?
@@ -526,7 +528,7 @@ function run_self_test(){
     echo
 
     # Enable core dump creation
-    pushd ${RUN_DIR}
+    pushd ${DUMP_DIR}/self_test
     ulimit -c unlimited
     eval $cmd
     popd
@@ -584,7 +586,7 @@ function run_mdtest(){
     echo
 
     # Enable core dump creation
-    pushd ${RUN_DIR}
+    pushd ${DUMP_DIR}/mdtest
     ulimit -c unlimited
     eval $cmd
     MDTEST_RC=$?

--- a/tests.sh
+++ b/tests.sh
@@ -61,13 +61,6 @@ echo
 
 echo DAOS_SERVERS=$DAOS_SERVERS
 
-cleanup(){
-    mkdir -p ${RUN_DIR}/${SLURM_JOB_ID}/cleanup
-    $SRUN_CMD ${DST_DIR}/copy_log_files.sh "cleanup"
-    $SRUN_CMD ${DST_DIR}/cleanup.sh ${DAOS_SERVERS}
-    echo "End Time: $(date)"
-}
-
 # Generate timestamp
 function time_stamp(){
     date +%m/%d-%H:%M:%S
@@ -77,6 +70,30 @@ function time_stamp(){
 function pmsg(){
     echo
     echo "$(time_stamp) ${1}"
+}
+
+function cleanup(){
+    pmsg "Removing temporary files"
+    ${SRUN_CMD} ${DST_DIR}/cleanup.sh
+    echo "End Time: $(date)"
+}
+
+function collect_test_logs(){
+    pmsg "Collecting metrics and logs"
+
+    # Server nodes
+    clush --hostfile ${SERVER_HOSTLIST_FILE} \
+    --command_timeout ${CMD_TIMEOUT} --groupbase -S " \
+    export PATH=${PATH}; export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
+    export RUN_DIR=${RUN_DIR}; export SLURM_JOB_ID=${SLURM_JOB_ID}; \
+    ${DST_DIR}/copy_log_files.sh server "
+
+    # Client nodes
+    clush --hostfile ${CLIENT_HOSTLIST_FILE} \
+    --command_timeout ${CMD_TIMEOUT} --groupbase -S " \
+    export PATH=${PATH}; export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
+    export RUN_DIR=${RUN_DIR}; export SLURM_JOB_ID=${SLURM_JOB_ID}; \
+    ${DST_DIR}/copy_log_files.sh client "
 }
 
 # Print command and run it, timestap is prefixed
@@ -127,9 +144,14 @@ function teardown_test(){
                       -f ${SLURM_JOB_NUM_NODES}"
     pmsg "Starting teardown"
 
-    sleep 10
+    collect_test_logs
+
+    pmsg "List test processes to be killed"
     eval "${CSH_PREFIX} -B \"pgrep -a ${PROCESSES}\""
+    pmsg "Killing test processes"
     eval "${CSH_PREFIX} \"pkill -e --signal SIGKILL ${PROCESSES}\""
+    sleep 1
+    pmsg "List surviving processes"
     eval "${CSH_PREFIX} -B \"pgrep -a ${PROCESSES}\""
 
     cleanup
@@ -139,7 +161,7 @@ function teardown_test(){
 
     pmsg "End of teardown"
 
-    pkill -P $$
+    pkill -e -P $$
 
     exit 0
 }
@@ -216,11 +238,11 @@ function wait_for_servers_to_start(){
 }
 
 #Create server/client hostfile.
-prepare(){
+function prepare(){
     #Create the folder for server/client logs.
     mkdir -p ${RUN_DIR}/${SLURM_JOB_ID}
     cp -v ${DST_DIR}/daos_*.yml ${RUN_DIR}/${SLURM_JOB_ID}
-    $SRUN_CMD ${DST_DIR}/create_log_dir.sh "cleanup"
+    ${SRUN_CMD} ${DST_DIR}/create_log_dir.sh
 
     if [ $MPI == "openmpi" ]; then
         ${DST_DIR}/openmpi_gen_hostlist.sh ${DAOS_SERVERS} ${DAOS_CLIENTS}
@@ -240,12 +262,15 @@ prepare(){
 }
 
 #Start DAOS agent
-start_agent(){
+function start_agent(){
     echo -e "\nCMD: Starting agent...\n"
     daos_cmd="daos_agent -o $DAOS_AGENT_YAML -s /tmp/daos_agent"
     cmd="clush --hostfile ${CLIENT_HOSTLIST_FILE}
-    -f $SLURM_JOB_NUM_NODES \"
-    export PATH=$PATH; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH;
+    -f ${SLURM_JOB_NUM_NODES} \"
+    pushd ${RUN_DIR};
+    ulimit -c unlimited;
+    export PATH=${PATH};
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH};
     export CPATH=${CPATH};
     export DAOS_DISABLE_REQ_FWD=${DAOS_DISABLE_REQ_FWD};
     $daos_cmd\" "
@@ -256,7 +281,7 @@ start_agent(){
 }
 
 #Dump attach info
-dump_attach_info(){
+function dump_attach_info(){
     echo -e "\nCMD: Dump attach info file...\n"
     cmd="daos_agent -i -o $DAOS_AGENT_YAML dump-attachinfo -o ${RUN_DIR}/${SLURM_JOB_ID}/daos_server.attach_info_tmp"
     echo $cmd
@@ -266,7 +291,7 @@ dump_attach_info(){
 }
 
 #Create Pool
-create_pool(){
+function create_pool(){
     pmsg "Creating pool"
 
     HOST=$(head -n 1 ${CLIENT_HOSTLIST_FILE})
@@ -297,7 +322,7 @@ create_pool(){
     sleep 10
 }
 
-setup_pool(){
+function setup_pool(){
     pmsg "Pool set-prop"
     run_cmd_on_client "dmg pool set-prop --pool=${POOL_UUID} --name=reclaim --value=disabled -o ${DAOS_CONTROL_YAML}"
 
@@ -312,7 +337,7 @@ setup_pool(){
 }
 
 #Create Container
-create_container(){
+function create_container(){
     echo -e "\nCMD: Creating container\n"
 
     CONT_UUID=$(uuidgen)
@@ -372,7 +397,7 @@ create_container(){
 }
 
 #Start daos servers
-start_server(){
+function start_server(){
     echo -e "\nCMD: Starting server...\n"
     daos_cmd="daos_server start -i -o $DAOS_SERVER_YAML --recreate-superblocks"
     cmd="clush --hostfile ${SERVER_HOSTLIST_FILE}
@@ -391,7 +416,7 @@ start_server(){
 }
 
 #Run IOR
-run_ior(){
+function run_ior(){
     echo -e "\nCMD: Starting IOR..."
     module unload intel
     module list
@@ -443,8 +468,13 @@ run_ior(){
 
     echo $cmd
     echo
+
+    # Enable core dump creation
+    pushd ${RUN_DIR}
+    ulimit -c unlimited
     eval $cmd
     IOR_RC=$?
+    popd
 
     module load intel
     module list
@@ -462,7 +492,7 @@ run_ior(){
 }
 
 #Run cart self_test
-run_self_test(){
+function run_self_test(){
     echo -e "\nCMD: Starting CaRT self_test...\n"
 
     let last_srv_index=$(( ${DAOS_SERVERS}-1 ))
@@ -494,7 +524,12 @@ run_self_test(){
 
     echo $cmd
     echo
+
+    # Enable core dump creation
+    pushd ${RUN_DIR}
+    ulimit -c unlimited
     eval $cmd
+    popd
 
     if [ $? -ne 0 ]; then
         echo -e "\nSTATUS: CART self_test FAIL\n"
@@ -504,7 +539,7 @@ run_self_test(){
     fi
 }
 
-run_mdtest(){
+function run_mdtest(){
     echo -e "\nCMD: Starting MDTEST...\n"
     module unload intel
     module list
@@ -547,8 +582,13 @@ run_mdtest(){
 
     echo $cmd
     echo
+
+    # Enable core dump creation
+    pushd ${RUN_DIR}
+    ulimit -c unlimited
     eval $cmd
     MDTEST_RC=$?
+    popd
 
     module load intel
     module list


### PR DESCRIPTION
Add a function to run daos_metrics on all the
server nodes to collect the telemetry data.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>