### PR TITLE
Miscellaneous fixes and enhancements

### DIFF
--- a/copy_log_files.sh
+++ b/copy_log_files.sh
@@ -7,7 +7,7 @@ echo "Copying logs from node $(hostname)"
 
 case ${NODE_TYPE} in
     server)
-    timeout --signal SIGKILL 1m daos_metrics -i 1 > ${LOG_DIR}/metrics.txt 2>&1
+    timeout --signal SIGKILL 1m daos_metrics -i 1 > ${LOG_DIR}/daos_metrics.txt 2>&1
     timeout --signal SIGKILL 1m dmesg > ${LOG_DIR}/dmesg_output.txt 2>&1
     ;;
 

--- a/daos_server.yml
+++ b/daos_server.yml
@@ -13,16 +13,10 @@ engines:
   - ABT_ENV_MAX_NUM_XSTREAMS=100
   - ABT_MAX_NUM_XSTREAMS=100
   - DAOS_MD_CAP=1024
-  - FI_SOCKETS_MAX_CONN_RETRY=1
-  - FI_SOCKETS_CONN_TIMEOUT=2000
   - DD_MASK=mgmt,io,md,epc,rebuild
   - PMEMOBJ_CONF=prefault.at_open=1;prefault.at_create=1;
   - PMEM_IS_PMEM_FORCE=1
-  - OFI_DOMAIN=mlx5_0
-  - FI_MR_CACHE_MAX_COUNT=0
   - FI_UNIVERSE_SIZE=16383
-  - FI_VERBS_PREFER_XRC=1
-  - FI_OFI_RXM_USE_SRX=1
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0

--- a/env_daos
+++ b/env_daos
@@ -1,8 +1,6 @@
 export FI_UNIVERSE_SIZE=16383
 export D_LOG_FILE=/tmp/daos_logs/daos_client.log
 export D_LOG_MASK=ERR
-export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
-export OFI_INTERFACE=ib0
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
 

--- a/env_daos
+++ b/env_daos
@@ -1,12 +1,8 @@
-export FI_MR_CACHE_MAX_COUNT=0
 export FI_UNIVERSE_SIZE=16383
-export FI_VERBS_PREFER_XRC=1
-export FI_OFI_RXM_USE_SRX=1
 export D_LOG_FILE=/tmp/daos_logs/daos_client.log
 export D_LOG_MASK=ERR
 export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
 export OFI_INTERFACE=ib0
-export OFI_DOMAIN=mlx5_0
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
 

--- a/env_daos
+++ b/env_daos
@@ -1,6 +1,9 @@
 export FI_UNIVERSE_SIZE=16383
 export D_LOG_FILE=/tmp/daos_logs/daos_client.log
 export D_LOG_MASK=ERR
+export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
+export OFI_INTERFACE=ib0
+export OFI_DOMAIN=mlx5_0
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
 

--- a/run_sbatch.sh
+++ b/run_sbatch.sh
@@ -24,7 +24,7 @@ pushd ${RUN_DIR}
 # Get TACC usage status
 /usr/local/etc/taccinfo > ${RUN_DIR}/tacc_usage_status.txt 2>&1
 
-SLURM_JOB="$(sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION ${DST_DIR}/tests.sh $TEST_GROUP)"
+SLURM_JOB="$(sbatch -J $JOBNAME -t $TIMEOUT --mail-user=$EMAIL -N $NNODE -n $NCORE -p $PARTITION ${DST_DIR}/sbatch_me.txt $TEST_GROUP)"
 
 echo "$(printf '%80s\n' | tr ' ' =)
 Running ${TESTCASE} with ${DAOS_SERVERS} servers and ${DAOS_CLIENTS} clients

--- a/run_testlist.py
+++ b/run_testlist.py
@@ -77,7 +77,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'SX'
                  },
                  'enabled': False
@@ -101,7 +101,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'SX'
                  },
                  'enabled': False
@@ -124,7 +124,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'RP_2GX'
                  },
                  'enabled': False
@@ -147,7 +147,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'RP_2GX'
                  },
                  'enabled': False
@@ -169,7 +169,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'RP_3GX'
                  },
                  'enabled': False
@@ -191,7 +191,7 @@ ior_testlist = [{'testcase': 'ior_easy_1to4_sx',
                      'pool_size': '85G',
                      'segments': '1',
                      'xfer_size': '1M',
-                     'block_size': '1G',
+                     'block_size': '150G',
                      'oclass': 'RP_3GX'
                  },
                  'enabled': False

--- a/sbatch_me.txt
+++ b/sbatch_me.txt
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#SBATCH -o stdout.o%j           # Name of stdout output file
+#SBATCH -e stderr.e%j           # Name of stderr error file
+#SBATCH -A STAR-Intel           # Project Name
+#SBATCH --mail-type=all         # Send email at begin and end of job
+
+mkdir -p ${RUN_DIR}
+
+${DST_DIR}/tests.sh ${1} |& tee ${RUN_DIR}/output_${SLURM_JOB_ID}.txt

--- a/tests.sh
+++ b/tests.sh
@@ -347,7 +347,6 @@ function create_container(){
     export DAOS_DISABLE_REQ_FWD=${DAOS_DISABLE_REQ_FWD};
     export DAOS_AGENT_DRPC_DIR=${DAOS_AGENT_DRPC_DIR};
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
-    export OFI_INTERFACE=${OFI_INTERFACE};
     export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
     $daos_cmd\""
 
@@ -369,7 +368,6 @@ function create_container(){
     export DAOS_DISABLE_REQ_FWD=${DAOS_DISABLE_REQ_FWD};
     export DAOS_AGENT_DRPC_DIR=${DAOS_AGENT_DRPC_DIR};
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
-    export OFI_INTERFACE=${OFI_INTERFACE};
     export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
     $daos_cmd\""
 
@@ -435,7 +433,6 @@ function run_ior(){
 
     prefix_openmpi="orterun $OMPI_PARAM
                  -x CPATH -x PATH -x LD_LIBRARY_PATH
-                 -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
                  -x FI_UNIVERSE_SIZE
                  -x D_LOG_FILE -x D_LOG_MASK
                  --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node
@@ -497,7 +494,6 @@ function run_self_test(){
 
     openmpi_cmd="orterun $OMPI_PARAM 
         -x CPATH -x PATH -x LD_LIBRARY_PATH
-        -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
         -x FI_UNIVERSE_SIZE
         --timeout $OMPI_TIMEOUT -np 1 --map-by node
         --hostfile ${CLIENT_HOSTLIST_FILE}
@@ -553,7 +549,6 @@ function run_mdtest(){
 
     openmpi_cmd="orterun $OMPI_PARAM
                 -x CPATH -x PATH -x LD_LIBRARY_PATH
-                -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
                 -x FI_UNIVERSE_SIZE
                 -x D_LOG_FILE -x D_LOG_MASK
                 --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node

--- a/tests.sh
+++ b/tests.sh
@@ -494,6 +494,7 @@ function run_self_test(){
 
     openmpi_cmd="orterun $OMPI_PARAM 
         -x CPATH -x PATH -x LD_LIBRARY_PATH
+        -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
         -x FI_UNIVERSE_SIZE
         --timeout $OMPI_TIMEOUT -np 1 --map-by node
         --hostfile ${CLIENT_HOSTLIST_FILE}

--- a/tests.sh
+++ b/tests.sh
@@ -538,7 +538,7 @@ function run_mdtest(){
                 --dfs.cont ${CONT_UUID}
                 --dfs.chunk_size ${CHUNK_SIZE}
                 --dfs.oclass ${OCLASS}
-                -L -p 10 -F -N 1 -P -d / -W 40
+                -L -p 10 -F -N 1 -P -d / -W 60
                 -e ${BYTES_READ} -w ${BYTES_WRITE} -z ${TREE_DEPTH}
                 -n ${N_FILE} -x ${RUN_DIR}/sw.${SLURM_JOB_ID} -v"
 

--- a/tests.sh
+++ b/tests.sh
@@ -415,7 +415,7 @@ function run_ior(){
              -a DFS -b ${BLOCK_SIZE} -C -e -w -W -g -G 27 -k -i 1
              -s ${SEGMENTS} -o /testFile
              -O stoneWallingWearOut=1
-             -O stoneWallingStatusFile=${RUN_DIR}/sw.${SLURM_JOB_ID} -D 40
+             -O stoneWallingStatusFile=${RUN_DIR}/sw.${SLURM_JOB_ID} -D 60
              -d 5 -t ${XFER_SIZE} --dfs.cont ${CONT_UUID}
              --dfs.group daos_server --dfs.pool ${POOL_UUID} --dfs.oclass ${OCLASS}
              --dfs.chunk_size ${CHUNK_SIZE} -v"
@@ -424,7 +424,7 @@ function run_ior(){
              -a DFS -b ${BLOCK_SIZE} -C -Q 1 -e -r -R -g -G 27 -k -i 1
              -s ${SEGMENTS} -o /testFile
              -O stoneWallingWearOut=1
-             -O stoneWallingStatusFile=${RUN_DIR}/sw.${SLURM_JOB_ID} -D 40
+             -O stoneWallingStatusFile=${RUN_DIR}/sw.${SLURM_JOB_ID} -D 60
              -d 5 -t ${XFER_SIZE} --dfs.cont ${CONT_UUID}
              --dfs.group daos_server --dfs.pool ${POOL_UUID} --dfs.oclass ${OCLASS}
              --dfs.chunk_size ${CHUNK_SIZE} -v"

--- a/tests.sh
+++ b/tests.sh
@@ -3,11 +3,6 @@
 #Run daos tests like IOR/MDtest and self_test(cart)
 #----------------------------------------------------
 
-#SBATCH -o stdout.o%j           # Name of stdout output file
-#SBATCH -e stderr.e%j           # Name of stderr error file
-#SBATCH -A STAR-Intel           # Project Name
-#SBATCH --mail-type=all         # Send email at begin and end of job
-
 #Unload modules that are not needed on Frontera
 module unload impi pmix hwloc
 module list
@@ -157,12 +152,9 @@ function teardown_test(){
 
     cleanup
 
-    # wait for all the background commands
-    wait
+    pkill -e --signal SIGKILL -P $$
 
     pmsg "End of teardown"
-
-    pkill -e -P $$
 
     exit 0
 }
@@ -355,11 +347,8 @@ function create_container(){
     export DAOS_DISABLE_REQ_FWD=${DAOS_DISABLE_REQ_FWD};
     export DAOS_AGENT_DRPC_DIR=${DAOS_AGENT_DRPC_DIR};
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
-    export OFI_DOMAIN=${OFI_DOMAIN}; export OFI_INTERFACE=${OFI_INTERFACE};
-    export FI_MR_CACHE_MAX_COUNT=${FI_MR_CACHE_MAX_COUNT};
+    export OFI_INTERFACE=${OFI_INTERFACE};
     export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
-    export FI_VERBS_PREFER_XRC=${FI_VERBS_PREFER_XRC};
-    export FI_OFI_RXM_USE_SRX=${FI_OFI_RXM_USE_SRX};
     $daos_cmd\""
 
     pmsg "CMD: ${daos_cmd}"
@@ -380,11 +369,8 @@ function create_container(){
     export DAOS_DISABLE_REQ_FWD=${DAOS_DISABLE_REQ_FWD};
     export DAOS_AGENT_DRPC_DIR=${DAOS_AGENT_DRPC_DIR};
     export D_LOG_FILE=${D_LOG_FILE}; export D_LOG_MASK=${D_LOG_MASK};
-    export OFI_DOMAIN=${OFI_DOMAIN}; export OFI_INTERFACE=${OFI_INTERFACE};
-    export FI_MR_CACHE_MAX_COUNT=${FI_MR_CACHE_MAX_COUNT};
+    export OFI_INTERFACE=${OFI_INTERFACE};
     export FI_UNIVERSE_SIZE=${FI_UNIVERSE_SIZE};
-    export FI_VERBS_PREFER_XRC=${FI_VERBS_PREFER_XRC};
-    export FI_OFI_RXM_USE_SRX=${FI_OFI_RXM_USE_SRX};
     $daos_cmd\""
 
     pmsg "CMD: ${daos_cmd}"
@@ -449,9 +435,8 @@ function run_ior(){
 
     prefix_openmpi="orterun $OMPI_PARAM
                  -x CPATH -x PATH -x LD_LIBRARY_PATH
-                 -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-                 -x FI_MR_CACHE_MAX_COUNT -x FI_UNIVERSE_SIZE
-                 -x FI_VERBS_PREFER_XRC -x FI_OFI_RXM_USE_SRX
+                 -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
+                 -x FI_UNIVERSE_SIZE
                  -x D_LOG_FILE -x D_LOG_MASK
                  --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node
                  --hostfile ${CLIENT_HOSTLIST_FILE}"
@@ -511,9 +496,9 @@ function run_self_test(){
         $st_cmd"
 
     openmpi_cmd="orterun $OMPI_PARAM 
-        -x CPATH -x PATH -x LD_LIBRARY_PATH -x FI_MR_CACHE_MAX_COUNT
-        -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-        -x FI_UNIVERSE_SIZE -x FI_VERBS_PREFER_XRC -x FI_OFI_RXM_USE_SRX
+        -x CPATH -x PATH -x LD_LIBRARY_PATH
+        -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
+        -x FI_UNIVERSE_SIZE
         --timeout $OMPI_TIMEOUT -np 1 --map-by node
         --hostfile ${CLIENT_HOSTLIST_FILE}
         $st_cmd"
@@ -568,9 +553,8 @@ function run_mdtest(){
 
     openmpi_cmd="orterun $OMPI_PARAM
                 -x CPATH -x PATH -x LD_LIBRARY_PATH
-                -x CRT_PHY_ADDR_STR -x OFI_DOMAIN -x OFI_INTERFACE
-                -x FI_MR_CACHE_MAX_COUNT -x FI_UNIVERSE_SIZE
-                -x FI_VERBS_PREFER_XRC -x FI_OFI_RXM_USE_SRX
+                -x CRT_PHY_ADDR_STR -x OFI_INTERFACE
+                -x FI_UNIVERSE_SIZE
                 -x D_LOG_FILE -x D_LOG_MASK
                 --timeout $OMPI_TIMEOUT -np $no_of_ps --map-by node
                 --hostfile ${CLIENT_HOSTLIST_FILE}
@@ -718,4 +702,4 @@ function run_testcase(){
 
 test=$1
 
-run_testcase |& tee ${RUN_DIR}/output_${SLURM_JOB_ID}.txt
+run_testcase


### PR DESCRIPTION
Make the test not return non zero by default.

Remove unused and deprecated env vars
* FI_OFI_RXM_USE_SRX
* FI_MR_CACHE_MAX_COUNT
* FI_VERBS_PREFER_XRC
* FI_SOCKETS_MAX_CONN_RETRY
* FI_SOCKETS_CONN_TIMEOUT
* OFI_DOMAIN

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>