### PR TITLE
add build_and_install_tools.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # daos_scaled_testing
-This repo contains execution scripts for Stampede2
+This repo contains execution scripts for Frontera.

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Modify Slurm related variables
 #SBATCH --mail-user=first.last@intel.com
 #SBATCH --mail-type=all         # Send email at begin and end of job
 
-Modiy DAOS related parameters
+Modify DAOS related parameters
 DAOS_SERVERS=4					# Number of DAOS servers
 DAOS_CLIENTS=2					# Number of DAOS clients
 ACCESS_PORT=10001 				# Access port

--- a/build_and_install_tools.sh
+++ b/build_and_install_tools.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [ $# -gt 0 ]; then
+    echo "Usage: $(basename $0)"
+    echo "Build and install some prerequisite packages."
+    exit 1
+fi
+
+BUILD_DIR=${SCRATCH}/BUILDS
+INSTALL_DIR=${HOME}/TOOLS
+
+# Unload modules that are not needed on Frontera
+module unload impi pmix hwloc intel python3
+module list
+
+mkdir -p ${BUILD_DIR}
+mkdir -p ${INSTALL_DIR}
+
+pushd ${BUILD_DIR}
+
+
+echo "===== Building hwloc ====="
+wget https://download.open-mpi.org/release/hwloc/v1.11/hwloc-1.11.5.tar.bz2
+tar -xvf hwloc-1.11.5.tar.bz2
+pushd ${BUILD_DIR}/hwloc-1.11.5
+./configure --prefix=${INSTALL_DIR}/hwloc
+make
+make install
+popd
+
+
+echo "===== Building openmpi ====="
+wget https://download.open-mpi.org/release/open-mpi/v3.1/openmpi-3.1.3.tar.bz2
+tar -xvf openmpi-3.1.3.tar.bz2
+pushd ${BUILD_DIR}/openmpi-3.1.3
+./configure --prefix=${INSTALL_DIR}/openmpi --with-hwloc=${INSTALL_DIR}/hwloc
+make
+make install
+popd
+
+
+echo "===== Building mpich ====="
+wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz
+tar -xvf mpich-3.3.2.tar.gz
+pushd ${BUILD_DIR}/mpich-3.3.2
+./autogen.sh
+./configure --prefix=${INSTALL_DIR}/mpich --enable-fortran=all --enable-romio \
+            --enable-cxx --enable-fast --disable-error-checking \
+            --without-timing --with-file-system=ufs --with-device=ch3:nemesis
+make
+make install
+popd
+
+
+popd
+
+
+echo "===== Done ====="
+

--- a/get_ior_results.sh
+++ b/get_ior_results.sh
@@ -68,7 +68,7 @@ function update_csv(){
     local CURRENT_FILE=${1}
     local RESULT_FILE=${2}
 
-    echo "  reaing file: ${CURRENT_FILE}"
+    echo "  reading file: ${CURRENT_FILE}"
 
     SERVERS=$(grep -E "^DAOS_SERVERS=" ${CURRENT_FILE} | cut -d '=' -f 2 | tr -d ' ')
     CLIENTS=$(get_value 'nodes' ${CURRENT_FILE})

--- a/get_mdtest_results.sh
+++ b/get_mdtest_results.sh
@@ -42,7 +42,7 @@ function update_csv(){
     local CURRENT_FILE=${1}
     local RESULT_FILE=${2}
 
-    echo "  reaing file: ${CURRENT_FILE}"
+    echo "  reading file: ${CURRENT_FILE}"
 
     SERVERS=$(get_value "DAOS_SERVERS=" ${CURRENT_FILE} = 2)
     RANKS=$(get_value "mdtest.*was launched" ${CURRENT_FILE} ' ' 5)


### PR DESCRIPTION
- Added build_and_install_tools.sh
  Builds and installs hwloc, openmpi, mpich.
- Some minor spelling errors and documentation updates

Co-authored-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>
Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>