### PR TITLE
use dmg pool create --properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # daos_scaled_testing
 This repo contains execution scripts for Frontera.
+
+## Version Compatibility
+Not all versions of this repo are compatible with all versions of DAOS.
+It may be necessary to use a specific commit when building or running tests
+against an older version of DAOS.
+
+| DAOS Commit   | Newest Compatible Script Commit |
+| ------------- | ------------------------------- |
+| master        | master |
+| v1.3.105-tb   | master |
+| v1.3.104-tb   | master |
+| v1.3.103-tb   | master |
+| v1.3.102-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |
+| v1.3.101-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |
+| v1.2.0        | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |

--- a/tests.sh
+++ b/tests.sh
@@ -203,26 +203,16 @@ function run_cmd_on_client(){
     check_cmd_timeout "${RC}" "${DAOS_CMD}" "${TEARDOWN_ON_ERROR}"
 }
 
-# Run dmg pool create. Use --label (new, required option) if available
+# Run dmg pool create
 function dmg_pool_create(){
     local POOL_LABEL="${1:-test_pool}"
 
-    if [ -z "${DMG_POOL_CREATE}" ]; then
-        DMG_POOL_CREATE="dmg -o ${DAOS_CONTROL_YAML} pool create"
-        run_cmd_on_client "${DMG_POOL_CREATE} --help" true true
-        if echo ${OUTPUT_CMD} | grep -qe "--label"; then
-            DMG_POOL_CREATE_HAS_LABEL=true
-        else
-            DMG_POOL_CREATE_HAS_LABEL=false
-        fi
-    fi
-
     pmsg "Creating pool ${POOL_LABEL}"
 
-    local cmd="${DMG_POOL_CREATE} --scm-size ${POOL_SIZE}"
-    if ${DMG_POOL_CREATE_HAS_LABEL} = true; then
-        cmd+=" --label ${POOL_LABEL}"
-    fi
+    local cmd="dmg -o ${DAOS_CONTROL_YAML} pool create
+               --scm-size ${POOL_SIZE}
+               --label ${POOL_LABEL}
+               --properties reclaim:disabled"
 
     run_cmd_on_client "${cmd}"
 
@@ -248,50 +238,29 @@ function dmg_pool_create_multi(){
     dmg_pool_list
 }
 
-# Run dmg pool list. Use --verbose (new option) if available
+# Run dmg pool list.
+# Use --verbose (new option) if available, added in v1.3.104-tb
 function dmg_pool_list(){
     if [ -z "${DMG_POOL_LIST}" ]; then
         DMG_POOL_LIST="dmg -o ${DAOS_CONTROL_YAML} pool list"
         run_cmd_on_client "${DMG_POOL_LIST} --help" true true
         if echo ${OUTPUT_CMD} | grep -qe "--verbose"; then
-            DMG_POOL_LIST+=" --verbose"
+            DMG_POOL_LIST+=" --verbose --no-query"
         fi
     fi
 
     run_cmd_on_client "${DMG_POOL_LIST}"
 }
 
-# Run dmg pool query. Use --pool (old option) if available
+# Run dmg pool query.
 function dmg_pool_query(){
     local UUID="${1}"
     local TEARDOWN_ON_ERROR="${2}"
 
-    if [ -z "${DMG_POOL_QUERY}" ]; then
-        DMG_POOL_QUERY="dmg -o ${DAOS_CONTROL_YAML} pool query"
-        run_cmd_on_client "${DMG_POOL_QUERY} --help" "${TEARDOWN_ON_ERROR}" true
-        if echo ${OUTPUT_CMD} | grep -qe "--pool"; then
-            DMG_POOL_QUERY+=" --pool"
-        fi
-    fi
+    local cmd="dmg -o ${DAOS_CONTROL_YAML} pool query
+              ${UUID}"
 
-    run_cmd_on_client "${DMG_POOL_QUERY} ${UUID}" "${TEARDOWN_ON_ERROR}"
-}
-
-# Run dmg pool set-prop. Use --pool (old option) if available
-function dmg_pool_set_prop(){
-    local UUID="${1}"
-    local NAME="${2}"
-    local VALUE="${3}"
-
-    if [ -z "${DMG_POOL_SET_PROP}" ]; then
-        DMG_POOL_SET_PROP="dmg -o ${DAOS_CONTROL_YAML} pool set-prop"
-        run_cmd_on_client "${DMG_POOL_SET_PROP} --help" true true
-        if echo ${OUTPUT_CMD} | grep -qe "--pool"; then
-            DMG_POOL_SET_PROP+=" --pool"
-        fi
-    fi
-
-    run_cmd_on_client "${DMG_POOL_SET_PROP} ${UUID} --name=${NAME} --value=${VALUE}"
+    run_cmd_on_client "${cmd}" "${TEARDOWN_ON_ERROR}"
 }
 
 function get_daos_status(){
@@ -475,20 +444,6 @@ function dump_attach_info(){
     echo
     eval $cmd &
     sleep 20
-}
-
-function setup_pool(){
-    pmsg "Pool set-prop"
-    dmg_pool_set_prop "${POOL_UUID}" "reclaim" "disabled"
-
-    if [ ${RC} -ne 0 ]; then
-        pmsg_err "dmg pool set-prop FAIL"
-        teardown_test
-    else
-        pmsg "dmg pool set-prop SUCCESS"
-    fi
-
-    sleep 10
 }
 
 function query_pools_rebuild(){
@@ -921,7 +876,6 @@ function run_testcase(){
             start_server
             start_agent
             dmg_pool_create
-            setup_pool
             create_container
             query_container
             run_ior_write
@@ -931,7 +885,6 @@ function run_testcase(){
             start_server
             start_agent
             dmg_pool_create
-            setup_pool
             create_container
             query_container
             run_ior
@@ -945,7 +898,6 @@ function run_testcase(){
             start_server
             start_agent
             dmg_pool_create
-            setup_pool
             create_container
             query_container
             run_mdtest


### PR DESCRIPTION
Use dmg pool create --properties instead of dmg pool set-prop.
Since this option was added in v1.3.103-tb, also remove
compatibility support for v1.3.102-tb.

Add a table of script/DAOS compatibilty to the README

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>