### PR TITLE
exit slurm job with correct rc

### DIFF
--- a/sbatch_me.txt
+++ b/sbatch_me.txt
@@ -8,3 +8,5 @@
 mkdir -p ${RUN_DIR}
 
 ${DST_DIR}/tests.sh ${1} |& tee ${RUN_DIR}/output_${SLURM_JOB_ID}.txt
+
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Exit with the rc from `tests.sh` instead of `rc=0` from the `tee` command

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>