### PR TITLE
revert ec_cell_size abbreviation

### DIFF
--- a/run_testlist.py
+++ b/run_testlist.py
@@ -171,8 +171,8 @@ ec_full_stripe_testdict = {
             (4, 8, 5)
         ],
         'ec_cell_size': [
-            ('64K'),
-            ('1M')
+            (65536),
+            (1048576)
         ],
         'oclass': 'EC_2P1GX',
         'env_vars': {
@@ -194,8 +194,8 @@ ec_full_stripe_testdict = {
             (6, 12, 5)
         ],
         'ec_cell_size': [
-            ('64K'),
-            ('1M')
+            (65536),
+            (1048576)
         ],
         'oclass': 'EC_4P2GX',
         'env_vars': {
@@ -217,8 +217,8 @@ ec_full_stripe_testdict = {
             (10, 20, 5)
         ],
         'ec_cell_size': [
-            ('64K'),
-            ('1M')
+            (65536),
+            (1048576)
         ],
         'oclass': 'EC_8P2GX',
         'env_vars': {
@@ -240,8 +240,8 @@ ec_full_stripe_testdict = {
             (18, 36, 5)
         ],
         'ec_cell_size': [
-            ('64K'),
-            ('1M')
+            (65536),
+            (1048576)
         ],
         'oclass': 'EC_16P2GX',
         'env_vars': {
@@ -593,7 +593,7 @@ class TestList(object):
     def _expand_default_test_params(self, test_params):
         for param, default in [
                 ('oclass', ['']),
-                ('ec_cell_size', ['1M'])]:
+                ('ec_cell_size', ['1048576'])]:
             if param not in test_params:
                 # Set default value
                 test_params[param] = default


### PR DESCRIPTION
Don't abbrevate ec_cell_size since it is not yet supported.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>