### PR TITLE
support ior write/read independent

### DIFF
--- a/frontera/run_testlist.py
+++ b/frontera/run_testlist.py
@@ -585,7 +585,7 @@ class TestList(object):
         self._test_group = test_group
         self._testdict = testdict
         self._env = env.copy()
-        self._setup_offset = 10
+        self._setup_offset = 5
         self._teardown_offset = 5
         self._pool_create_timeout = 3
         self._cmd_timeout = 2


### PR DESCRIPTION
- Support running ior write and read independently, but using the same
stonewall file.

- Also reduce the default setup_offset to 5, since it realistically only
  takes up to 2-3 minutes even for 128 servers.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>