### PR TITLE
miscellaneous improvements

### DIFF
--- a/frontera/build_and_install_tools.sh
+++ b/frontera/build_and_install_tools.sh
@@ -10,7 +10,7 @@ if [ $# -gt 0 ]; then
 fi
 
 BUILD_DIR=${SCRATCH}/BUILDS
-INSTALL_DIR=${HOME}/TOOLS
+INSTALL_DIR=${WORK}/TOOLS
 
 # Unload modules that are not needed on Frontera
 module unload impi pmix hwloc intel python3

--- a/frontera/get_results.py
+++ b/frontera/get_results.py
@@ -3,12 +3,12 @@
 """
     Gathers ior and mdtest results into csv format.
     Examples:
-    - Get all ior and mdtest results
-        ./get_results.py /work2/08126/dbohninx/frontera/RESULTS
+    - Get all test results
+        ./get_results.py $WORK/RESULTS
     - Get just ior results
-        ./get_results.py /work2/08126/dbohninx/frontera/RESULTS --no-mdtest
+        ./get_results.py $WORK/RESULTS --tests ior
     - Get and email all results
-        ./get_results.py /work2/08126/dbohninx/frontera/RESULTS --email dalton
+        ./get_results.py $WORK/RESULTS --email dalton
 """
 
 import re

--- a/frontera/run_build.sh
+++ b/frontera/run_build.sh
@@ -7,11 +7,11 @@
 EXTRA_BUILD="${1}"
 
 # Directory to build in
-export BUILD_DIR="$WORK2/BUILDS/"
+export BUILD_DIR="${WORK}/BUILDS/"
 
 # Only if building with mpich or openmpi
-export MPICH_DIR="<path_to_mpich>"     # e.g. /scratch/POC/mpich
-export OPENMPI_DIR="<path_to_openmpi>" # e.g. /scratch/POC/openmpi
+export MPICH_DIR="${WORK}/TOOLS/mpich" # Path to locally built mpich
+export OPENMPI_DIR="${WORK}/TOOLS/openmpi" # Path to locally built openmpi
 
 # DAOS branch to clone
 DAOS_BRANCH="master"

--- a/frontera/run_build_on_compute_node.sh
+++ b/frontera/run_build_on_compute_node.sh
@@ -5,8 +5,8 @@
 
 JOBNAME="<sbatch_jobname>"
 EMAIL="<email>" #<first.last@email.com>
-export BUILD_DIR="<path_build_area>" #e.g./scratch/POC/BUILDS/
-export DST_DIR="<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
+export BUILD_DIR="${WORK}/BUILDS/" # Directory to build in
+export DST_DIR="$(realpath ../)" # Path to daos_scaled_testing repo
 
 if [ ! -d "${BUILD_DIR}" ]; then
     echo "BUILD_DIR not found: ${BUILD_DIR}"

--- a/frontera/run_sbatch.sh
+++ b/frontera/run_sbatch.sh
@@ -9,7 +9,7 @@ export DAOS_DIR
 export TESTCASE
 export LOGS=${RES_DIR}/${TIMESTAMP}/${TESTCASE}
 export RUN_DIR=${LOGS}/log_${DAOS_SERVERS}
-mkdir -p ${RUN_DIR}
+mkdir -p ${RUN_DIR} || exit
 
 export DAOS_SERVERS
 export DAOS_CLIENTS

--- a/frontera/run_testlist.py
+++ b/frontera/run_testlist.py
@@ -5,7 +5,7 @@
 '''
 
 import os
-from os.path import isdir, isfile, join
+from os.path import isdir, isfile, join, expandvars, realpath
 import subprocess
 import itertools
 
@@ -17,15 +17,15 @@ env['LD_LIBRARY_PATH'] = "/opt/apps/intel19/python3/3.7.0/lib:/opt/intel/debugge
 
 env['JOBNAME']     = "<sbatch_jobname>"
 env['EMAIL']       = "<email>" # <first.last@email.com>
-env['DAOS_DIR']    = "<path_to_daos>" # E.g. /work2/08126/dbohninx/frontera/BUILDS/latest/daos
-env['DST_DIR']     = "<path_to_daos_scaled_testing>" # E.g. /scratch/TESTS/daos_scaled_testing
-env['RES_DIR']     = "<path_to_result_dir>" # E.g. /home1/06753/soychan/work/POC/TESTS/dst_framework/RESULTS
+env['DAOS_DIR']    = realpath(expandvars("${WORK}/BUILDS/latest/daos")) # Path to daos
+env['DST_DIR']     = realpath(expandvars("../")) # Path to daos_scaled_testing repo
+env['RES_DIR']     = realpath(expandvars("${WORK}/RESULTS")) # Path to test results
 
 env['MPI_TARGET']  = "mvapich2" # mvapich2, openmpi, mpich
 
 # Only if using MPICH or OPENMPI
-env['MPICH_DIR']   = "<path_to_mpich>" #e.g./scratch/POC/mpich
-env['OPENMPI_DIR'] = "<path_to_openmpi>" #e.g./scratch/POC/openmpi
+env['MPICH_DIR']   = realpath(expandvars("${WORK}/TOOLS/mpich")) # Path to locally built mpich
+env['OPENMPI_DIR'] = realpath(expandvars("${WORK}/TOOLS/openmpi")) # Path to locall build openmpi
 
 # Sanity check that directories exist
 for check_dir in (env['DAOS_DIR'], env['DST_DIR']):

--- a/frontera/run_testlist.py
+++ b/frontera/run_testlist.py
@@ -33,8 +33,6 @@ for check_dir in (env['DAOS_DIR'], env['DST_DIR']):
         print("ERROR: Not a directory: {}".format(check_dir))
         exit(1)
 
-# TODO create RES_DIR here first to make sure it's valid
-
 # Sanity check that it's actually a DAOS installation
 if not isfile(join(env['DAOS_DIR'], "../repo_info.txt")):
     print("ERROR: {} doesn't seem to be a DAOS installation".format(env['DAOS_DIR']))
@@ -45,7 +43,6 @@ if not env['MPI_TARGET'] in ('mvapich2', 'openmpi', 'mpich'):
     print("ERROR: invalid MPI_TARGET {}".format(env['MPI_TARGET']))
     exit(1)
 
-# TODO refactor to make 'inflight' a variant?
 self_testdict = {
     'st_1tomany_cli2srv_inf1': {
         'scale': [

--- a/frontera/run_weekly.sh
+++ b/frontera/run_weekly.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DST_DIR="<path_to_daos_scaled_testing>" #/scratch/TESTS/daos_scaled_testing
+DST_DIR="$(realpath ../)" # Path to daos_scaled_testing repo
 
 if [ ! -d "${DST_DIR}" ]; then
     echo "DST_DIR not found: ${DST_DIR}"

--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -43,6 +43,8 @@ fi
 
 # Print all relevant test params / env variables
 echo "SLURM_JOB_ID    : ${SLURM_JOB_ID}"
+echo "JOBNAME         : ${JOBNAME}"
+echo "EMAIL           : ${EMAIL}"
 echo "TESTCASE        : ${TESTCASE}"
 echo "OCLASS          : ${OCLASS}"
 echo "DIR_OCLASS      : ${DIR_OCLASS}"
@@ -89,13 +91,10 @@ PROCESSES="'(daos|orteun|mpirun)'"
 # Time in milliseconds
 CLOCK_DRIFT_THRESHOLD=500
 
-HOSTNAME=$(hostname)
-echo "hostname:"
-echo $HOSTNAME
+echo "Test runner hostname: ${HOSTNAME}"
 echo
 echo "DAOS_DIR:"
-BUILD=`ls -ald $(realpath ${DAOS_DIR}/../.)`
-echo $BUILD
+echo "$(ls -ald $(realpath ${DAOS_DIR}/../.))"
 
 mkdir -p ${RUN_DIR}
 cp -v ${DAOS_DIR}/../repo_info.txt ${RUN_DIR}/${SLURM_JOB_ID}/repo_info.txt


### PR DESCRIPTION
- create container with label
  - Create container with label
  - Rename cont create and cont query
  - Parameterize cont create and cont query

- print JOBNAME, EMAIL and remove some globals
  - print JOBNAME and EMAIL
  - remove some globally define vars

- address TODO items
  - inflight doesn't need to be a variant at this time
  - exit if RUN_DIR fails to be created, before scheduling the slurm job

- update and simplify path usage
  - Install in $WORK by default, not $HOME or $SCRATCH
  - Set default paths to actual paths