### PR TITLE
support passing configs to run_testlist.py

### DIFF
--- a/frontera/run_sbatch.sh
+++ b/frontera/run_sbatch.sh
@@ -32,7 +32,7 @@ SLURM_JOB="$(sbatch -J $JOBNAME \
                     -n $NCORE \
                     -p $PARTITION \
                     --begin=now+5 \
-                    ${DST_DIR}/frontera/sbatch_me.txt $TEST_GROUP)"
+                    ${DST_DIR}/frontera/sbatch_me.txt)"
 
 echo "$(printf '%80s\n' | tr ' ' =)
 Running ${TESTCASE} with ${DAOS_SERVERS} servers and ${DAOS_CLIENTS} clients
@@ -42,5 +42,5 @@ ${SLURM_JOB}" |& tee -a ${RES_DIR}/${TIMESTAMP}/job_list.txt
 echo ""
 SLURM_JOB_ID="${SLURM_JOB##* }"
 mkdir -p "${RUN_DIR}/${SLURM_JOB_ID}"
-cp -v ${DST_DIR}/frontera/daos_*.yml ${RUN_DIR}/${SLURM_JOB_ID}
-cp -v ${DST_DIR}/frontera/env_daos ${RUN_DIR}/${SLURM_JOB_ID}/env_daos
+cp ${DST_DIR}/frontera/daos_*.yml ${RUN_DIR}/${SLURM_JOB_ID}
+cp ${DST_DIR}/frontera/env_daos ${RUN_DIR}/${SLURM_JOB_ID}/env_daos

--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -45,6 +45,7 @@ fi
 echo "SLURM_JOB_ID    : ${SLURM_JOB_ID}"
 echo "JOBNAME         : ${JOBNAME}"
 echo "EMAIL           : ${EMAIL}"
+echo "TEST_GROUP      : ${TEST_GROUP}"
 echo "TESTCASE        : ${TESTCASE}"
 echo "OCLASS          : ${OCLASS}"
 echo "DIR_OCLASS      : ${DIR_OCLASS}"
@@ -844,7 +845,7 @@ function kill_random_server(){
 }
 
 function run_testcase(){
-    local testcase=$1
+    local test_group=$1
 
     echo "###################"
     echo "RUN: ${TESTCASE}"
@@ -856,7 +857,7 @@ function run_testcase(){
     # System sanity check
     check_clock_sync
 
-    case ${testcase} in
+    case ${test_group} in
         SWIM)
             # Swim stabilization test by checking server fault detection
             start_server
@@ -902,4 +903,4 @@ function run_testcase(){
     teardown_test "Success!" 0
 }
 
-run_testcase $1
+run_testcase $TEST_GROUP

--- a/frontera/tests/README.md
+++ b/frontera/tests/README.md
@@ -1,0 +1,2 @@
+# daos_scaled_testing/frontera/tests
+Contains test configs.

--- a/frontera/tests/basic/ior_easy.py
+++ b/frontera/tests/basic/ior_easy.py
@@ -1,0 +1,50 @@
+'''
+    Basic IOR easy tests with rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '1',
+    'xfer_size': '1M',
+    'block_size': '150G',
+    'sw_time': '60',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy',
+        'oclass': 'SX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 4, 10),
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (1, 16, 10),
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/basic/ior_hard.py
+++ b/frontera/tests/basic/ior_hard.py
@@ -1,0 +1,50 @@
+'''
+    Basic IOR hard tests with rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '2000000',
+    'xfer_size': '47008',
+    'block_size': '47008',
+    'sw_time': '60',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_hard',
+        'oclass': 'SX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 4, 10),
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (1, 16, 10),
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/basic/mdtest_easy.py
+++ b/frontera/tests/basic/mdtest_easy.py
@@ -1,0 +1,50 @@
+'''
+    Basic MdTest easy tests with rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'n_file': '1000000',
+    'bytes_read': '0',
+    'bytes_write': '0',
+    'tree_depth': '0',
+    'sw_time': '60',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_easy',
+        'oclass': [('S1', 'SX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 4, 10),
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (1, 16, 10),
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/basic/mdtest_hard.py
+++ b/frontera/tests/basic/mdtest_hard.py
@@ -1,0 +1,50 @@
+'''
+    Basic MdTest hard tests with rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'n_file': '200000',
+    'bytes_read': '3901',
+    'bytes_write': '3901',
+    'tree_depth': '0/20',
+    'sw_time': '60',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_hard',
+        'oclass': [('S1', 'SX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 4, 10),
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (1, 16, 10),
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/ec/ior_full_stripe.py
+++ b/frontera/tests/ec/ior_full_stripe.py
@@ -1,0 +1,81 @@
+'''
+    IOR full stripe EC tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '32M',
+    'segments': '1',
+    'xfer_size': None, # placeholder
+    'block_size': '1G',
+    'fpp': '-F',
+    'sw_time': '60',
+    'iterations': '2',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_full_stripe_EC_2P1GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (4, 8, 10)
+        ],
+        'ec_cell_size': [
+            (65536),
+            (1048576)
+        ],
+        'oclass': 'EC_2P1GX',
+        'env_vars': dict(env_vars, xfer_size='2M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_full_stripe_EC_4P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (6, 12, 10)
+        ],
+        'ec_cell_size': [
+            (65536),
+            (1048576)
+        ],
+        'oclass': 'EC_4P2GX',
+        'env_vars': dict(env_vars, xfer_size='4M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_full_stripe_EC_8P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (10, 20, 10)
+        ],
+        'ec_cell_size': [
+            (65536),
+            (1048576)
+        ],
+        'oclass': 'EC_8P2GX',
+        'env_vars': dict(env_vars, xfer_size='8M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_full_stripe_EC_16P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (18, 36, 10)
+        ],
+        'ec_cell_size': [
+            (65536),
+            (1048576)
+        ],
+        'oclass': 'EC_16P2GX',
+        'env_vars': dict(env_vars, xfer_size='16M'),
+        'enabled': False
+    },
+]

--- a/frontera/tests/ec/ior_partial_stripe.py
+++ b/frontera/tests/ec/ior_partial_stripe.py
@@ -1,0 +1,65 @@
+'''
+    IOR partial stripe EC tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '32M',
+    'segments': '1',
+    'xfer_size': '1M',
+    'block_size': '1G',
+    'fpp': '-F',
+    'sw_time': '60',
+    'iterations': '2',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_partial_stripe_EC_2P1GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (4, 8, 10)
+        ],
+        'oclass': 'EC_2P1GX',
+        'env_vars': dict(env_vars),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_partial_stripe_EC_4P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (6, 12, 10)
+        ],
+        'oclass': 'EC_4P2GX',
+        'env_vars': dict(env_vars),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_partial_stripe_EC_8P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (10, 20, 10)
+        ],
+        'oclass': 'EC_8P2GX',
+        'env_vars': dict(env_vars),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ec_ior_partial_stripe_EC_16P2GX',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (18, 36, 10)
+        ],
+        'oclass': 'EC_16P2GX',
+        'env_vars': dict(env_vars),
+        'enabled': False
+    },
+]

--- a/frontera/tests/ec_vs_rf0/ior_easy.py
+++ b/frontera/tests/ec_vs_rf0/ior_easy.py
@@ -1,0 +1,77 @@
+'''
+    ior_easy tests to compare EC to rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': None, # placeholder
+    'ec_cell_size': '1048576',
+    'segments': '1',
+    'xfer_size': None, # placeholder
+    'block_size': '150G',
+    'sw_time': '60', # TODO adjust?
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of oclass, chunk_size, xfer_size, scale
+condensed_tests = [
+    ['S32',      '1M',  '2M', [(3, 12, 10)]],
+    ['S32',      '1M',  '2M', [(3, 16, 10)]],
+    ['S64',      '1M',  '2M', [(6, 12, 10)]],
+    ['S64',      '1M',  '2M', [(6, 16, 10)]],
+    ['S128',     '1M',  '2M', [(12, 16, 10)]],
+    ['S192',     '1M',  '2M', [(18, 16, 10)]],
+    ['S256',     '1M',  '2M', [(24, 16, 10)]],
+
+    ['EC_2P1GX', '2M',  '2M', [(3, 12, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(3, 16, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(6, 12, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(6, 16, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(12, 16, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(18, 16, 10)]],
+    ['EC_2P1GX', '2M',  '2M', [(24, 16, 10)]],
+
+    ['S64',      '1M',  '4M', [(6, 12, 10)]],
+    ['S64',      '1M',  '4M', [(6, 16, 10)]],
+    ['S128',     '1M',  '4M', [(12, 16, 10)]],
+    ['S192',     '1M',  '4M', [(18, 16, 10)]],
+    ['S256',     '1M',  '4M', [(24, 16, 10)]],
+    ['S384',     '1M',  '4M', [(36, 16, 10)]],
+
+    ['EC_4P2GX', '4M',  '4M', [(6, 12, 10)]],
+    ['EC_4P2GX', '4M',  '4M', [(6, 16, 10)]],
+    ['EC_4P2GX', '4M',  '4M', [(12, 16, 10)]],
+    ['EC_4P2GX', '4M',  '4M', [(18, 16, 10)]],
+    ['EC_4P2GX', '4M',  '4M', [(24, 16, 10)]],
+    ['EC_4P2GX', '4M',  '4M', [(36, 16, 10)]],
+
+    ['S128',     '1M',  '8M', [(10, 16, 10)]],
+    ['S256',     '1M',  '8M', [(20, 16, 10)]],
+    ['S384',     '1M',  '8M', [(30, 16, 10)]],
+
+    ['EC_8P2GX', '8M',  '8M', [(10, 16, 10)]],
+    ['EC_8P2GX', '8M',  '8M', [(20, 16, 10)]],
+    ['EC_8P2GX', '8M',  '8M', [(30, 16, 10)]],
+
+    ['S256',     '1M',  '16M', [(18, 16, 10)]],
+    ['S512',     '1M',  '16M', [(36, 16, 10)]],
+
+    ['EC_8P2GX', '16M', '16M', [(18, 16, 10)]],
+    ['EC_8P2GX', '16M', '16M', [(36, 16, 10)]],
+]
+
+# List of tests, generated from condensed_tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy',
+        'oclass': _oclass,
+        'scale': _scale,
+        'env_vars': dict(env_vars, chunk_size=_chunk, xfer_size=_xfer),
+        'enabled': True
+    }
+    for _oclass, _chunk, _xfer, _scale in condensed_tests
+]

--- a/frontera/tests/ec_vs_rf0/ior_hard.py
+++ b/frontera/tests/ec_vs_rf0/ior_hard.py
@@ -1,0 +1,77 @@
+'''
+    ior_hard tests to compare EC to rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': None, # placeholder
+    'ec_cell_size': '1048576',
+    'segments': '2000000',
+    'xfer_size': '47008',
+    'block_size': '47008',
+    'sw_time': '60',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of oclass, chunk_size, scale
+condensed_tests = [
+    ['S32',      '1M',  [(3, 12, 10)]],
+    ['S32',      '1M',  [(3, 16, 10)]],
+    ['S64',      '1M',  [(6, 12, 10)]],
+    ['S64',      '1M',  [(6, 16, 10)]],
+    ['S128',     '1M',  [(12, 16, 10)]],
+    ['S192',     '1M',  [(18, 16, 10)]],
+    ['S256',     '1M',  [(24, 16, 10)]],
+
+    ['EC_2P1GX', '2M',  [(3, 12, 10)]],
+    ['EC_2P1GX', '2M',  [(3, 16, 10)]],
+    ['EC_2P1GX', '2M',  [(6, 12, 10)]],
+    ['EC_2P1GX', '2M',  [(6, 16, 10)]],
+    ['EC_2P1GX', '2M',  [(12, 16, 10)]],
+    ['EC_2P1GX', '2M',  [(18, 16, 10)]],
+    ['EC_2P1GX', '2M',  [(24, 16, 10)]],
+
+    ['S64',      '1M',  [(6, 12, 10)]],
+    ['S64',      '1M',  [(6, 16, 10)]],
+    ['S128',     '1M',  [(12, 16, 10)]],
+    ['S192',     '1M',  [(18, 16, 10)]],
+    ['S256',     '1M',  [(24, 16, 10)]],
+    ['S384',     '1M',  [(36, 16, 10)]],
+
+    ['EC_4P2GX', '4M',  [(6, 12, 10)]],
+    ['EC_4P2GX', '4M',  [(6, 16, 10)]],
+    ['EC_4P2GX', '4M',  [(12, 16, 10)]],
+    ['EC_4P2GX', '4M',  [(18, 16, 10)]],
+    ['EC_4P2GX', '4M',  [(24, 16, 10)]],
+    ['EC_4P2GX', '4M',  [(36, 16, 10)]],
+
+    ['S128',     '1M',  [(10, 16, 10)]],
+    ['S256',     '1M',  [(20, 16, 10)]],
+    ['S384',     '1M',  [(30, 16, 10)]],
+
+    ['EC_8P2GX', '8M',  [(10, 16, 10)]],
+    ['EC_8P2GX', '8M',  [(20, 16, 10)]],
+    ['EC_8P2GX', '8M',  [(30, 16, 10)]],
+
+    ['S256',     '1M',  [(18, 16, 10)]],
+    ['S512',     '1M',  [(36, 16, 10)]],
+
+    ['EC_8P2GX', '16M', [(18, 16, 10)]],
+    ['EC_8P2GX', '16M', [(36, 16, 10)]],
+]
+
+# List of tests, generated from condensed_tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_hard',
+        'oclass': _oclass,
+        'scale': _scale,
+        'env_vars': dict(env_vars, chunk_size=_chunk),
+        'enabled': True
+    }
+    for _oclass, _chunk, _scale in condensed_tests
+]

--- a/frontera/tests/ec_vs_rf0/mdtest_easy.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_easy.py
@@ -1,0 +1,77 @@
+'''
+    mdtest_easy tests to compare EC to rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': None, # placeholder
+    'ec_cell_size': '1048576',
+    'n_file': '1000000',
+    'bytes_read': '0',
+    'bytes_write': '0',
+    'tree_depth': '0',
+    'sw_time': '60', # TODO adjust?
+    'ppc': 32
+}
+
+# List of oclass, chunk_size, scale
+condensed_tests = [
+    [[('S2', 'SX')],            '1M',  [(3, 12, 10)]],
+    [[('S2', 'SX')],            '1M',  [(3, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(6, 12, 10)]],
+    [[('S2', 'SX')],            '1M',  [(6, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(12, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(18, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(24, 16, 10)]],
+
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(3, 12, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(3, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(6, 12, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(6, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(12, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(18, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(24, 16, 10)]],
+
+    [[('S4', 'SX')],            '1M',  [(6, 12, 10)]],
+    [[('S4', 'SX')],            '1M',  [(6, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(12, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(18, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(24, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(36, 16, 10)]],
+
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(6, 12, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(6, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(12, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(18, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(24, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(36, 16, 10)]],
+
+    [[('S8', 'SX')],            '1M',  [(10, 16, 10)]],
+    [[('S8', 'SX')],            '1M',  [(20, 16, 10)]],
+    [[('S8', 'SX')],            '1M',  [(30, 16, 10)]],
+
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(10, 16, 10)]],
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(20, 16, 10)]],
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(30, 16, 10)]],
+
+    [[('S16', 'SX')],           '1M',  [(18, 16, 10)]],
+    [[('S16', 'SX')],           '1M',  [(36, 16, 10)]],
+
+    [[('EC_16P2G1', 'RP_3GX')], '16M', [(18, 16, 10)]],
+    [[('EC_16P2G1', 'RP_3GX')], '16M', [(36, 16, 10)]],
+]
+
+# List of tests, generated from condensed_tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_easy',
+        'oclass': _oclass,
+        'scale': _scale,
+        'env_vars': dict(env_vars, chunk_size=_chunk),
+        'enabled': True
+    }
+    for _oclass, _chunk, _scale in condensed_tests
+]

--- a/frontera/tests/ec_vs_rf0/mdtest_hard.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_hard.py
@@ -1,0 +1,77 @@
+'''
+    mdtest_hard tests to compare EC to rf0.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': None, # placeholder
+    'ec_cell_size': '1048576',
+    'n_file': '1000000',
+    'bytes_read': '3901',
+    'bytes_write': '3901',
+    'tree_depth': '0/20',
+    'sw_time': '60', # TODO adjust?
+    'ppc': 32
+}
+
+# List of oclass, chunk_size, scale
+condensed_tests = [
+    [[('S2', 'SX')],            '1M',  [(3, 12, 10)]],
+    [[('S2', 'SX')],            '1M',  [(3, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(6, 12, 10)]],
+    [[('S2', 'SX')],            '1M',  [(6, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(12, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(18, 16, 10)]],
+    [[('S2', 'SX')],            '1M',  [(24, 16, 10)]],
+
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(3, 12, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(3, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(6, 12, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(6, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(12, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(18, 16, 10)]],
+    [[('EC_2P1G1', 'RP_2GX')],  '2M',  [(24, 16, 10)]],
+
+    [[('S4', 'SX')],            '1M',  [(6, 12, 10)]],
+    [[('S4', 'SX')],            '1M',  [(6, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(12, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(18, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(24, 16, 10)]],
+    [[('S4', 'SX')],            '1M',  [(36, 16, 10)]],
+
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(6, 12, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(6, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(12, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(18, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(24, 16, 10)]],
+    [[('EC_4P2G1', 'RP_3GX')],  '4M',  [(36, 16, 10)]],
+
+    [[('S8', 'SX')],            '1M',  [(10, 16, 10)]],
+    [[('S8', 'SX')],            '1M',  [(20, 16, 10)]],
+    [[('S8', 'SX')],            '1M',  [(30, 16, 10)]],
+
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(10, 16, 10)]],
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(20, 16, 10)]],
+    [[('EC_8P2G1', 'RP_3GX')],  '8M',  [(30, 16, 10)]],
+
+    [[('S16', 'SX')],           '1M',  [(18, 16, 10)]],
+    [[('S16', 'SX')],           '1M',  [(36, 16, 10)]],
+
+    [[('EC_16P2G1', 'RP_3GX')], '16M', [(18, 16, 10)]],
+    [[('EC_16P2G1', 'RP_3GX')], '16M', [(36, 16, 10)]],
+]
+
+# List of tests, generated from condensed_tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_hard',
+        'oclass': _oclass,
+        'scale': _scale,
+        'env_vars': dict(env_vars, chunk_size=_chunk),
+        'enabled': True
+    }
+    for _oclass, _chunk, _scale in condensed_tests
+]

--- a/frontera/tests/rebuild/empty_ec.py
+++ b/frontera/tests/rebuild/empty_ec.py
@@ -1,0 +1,46 @@
+'''
+    Rebuild EC tests with empty pool(s).
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'number_of_pools': '1',
+    'pool_size': '85G',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'SWIM',
+        'test_name': 'rebuild_pool_single',
+        'oclass': 'EC_16P2GX',
+        'ec_cell_size': 65536, # 1M chunk / 16
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (64, 1, 10),
+        ],
+        'env_vars': dict(
+            env_vars,
+            cont_rf=2),
+        'enabled': True
+    },
+    {
+        'test_group': 'SWIM',
+        'test_name': 'rebuild_pool_multi',
+        'oclass': 'EC_16P2GX',
+        'ec_cell_size': 65536, # 1M chunk / 16
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (64, 1, 15),
+        ],
+        'env_vars': dict(
+            env_vars,
+            cont_rf=2,
+            number_of_pools=73,
+            pool_size='256MiB', # Minimum 16MiB per rank
+        ),
+        'enabled': True
+    },
+]

--- a/frontera/tests/rebuild/load_ec.py
+++ b/frontera/tests/rebuild/load_ec.py
@@ -1,0 +1,36 @@
+'''
+    Rebuild EC tests with pool load.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'number_of_pools': '1',
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '1',
+    'xfer_size': '1M',
+    'block_size': None, # placeholder
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'SWIM_IOR',
+        'test_name': 'rebuild_pool_load',
+        'oclass': 'EC_16P2GX',
+        'ec_cell_size': 65536, # 1M chunk / 16
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (64, 4, 10),
+        ],
+        'env_vars': dict(
+            env_vars,
+            cont_rf=2,
+            ppc=56,
+            block_size='6G'),
+        'enabled': True
+    },
+]

--- a/frontera/tests/repl/ior_easy.py
+++ b/frontera/tests/repl/ior_easy.py
@@ -1,0 +1,74 @@
+'''
+    Standard IOR easy replication tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '1',
+    'xfer_size': '1M',
+    'block_size': '150G',
+    'sw_time': '60',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy',
+        'oclass': 'RP_2GX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy',
+        'oclass': 'RP_3GX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/repl/ior_hard.py
+++ b/frontera/tests/repl/ior_hard.py
@@ -1,0 +1,74 @@
+'''
+    Standard IOR hard replication.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '2000000',
+    'xfer_size': '47008',
+    'block_size': '47008',
+    'sw_time': '60',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_hard',
+        'oclass': 'RP_2GX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_hard',
+        'oclass': 'RP_3GX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/repl/mdtest_easy.py
+++ b/frontera/tests/repl/mdtest_easy.py
@@ -1,0 +1,74 @@
+'''
+    Standard MdTest easy replication tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'n_file': '1000000',
+    'bytes_read': '0',
+    'bytes_write': '0',
+    'tree_depth': '0',
+    'sw_time': '60',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_easy',
+        'oclass': [('RP_2G1', 'RP_2GX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_easy',
+        'oclass': [('RP_3G1', 'RP_3GX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/repl/mdtest_hard.py
+++ b/frontera/tests/repl/mdtest_hard.py
@@ -1,0 +1,74 @@
+'''
+    Standard MdTest hard replication tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'n_file': '200000',
+    'bytes_read': '3901',
+    'bytes_write': '3901',
+    'tree_depth': '0/20',
+    'sw_time': '60',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_hard',
+        'oclass': [('RP_2G1', 'RP_2GX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (2, 8, 10),
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            (2, 16, 10),
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_hard',
+        'oclass': [('RP_3G1', 'RP_3GX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (4, 16, 10),
+            (8, 32, 10),
+            #(16, 64, 10),
+            #(32, 128, 10),
+            #(64, 256, 10),
+            #(128, 512, 10),
+            #(256, 1024, 10),
+
+            # c16, (num_servers, num_clients, timeout_minutes)
+            #(4, 16, 10), # duplicate of 1to4
+            (8, 16, 10),
+            (16, 16, 10),
+            (32, 16, 10),
+            (64, 16, 10),
+            #(128, 16, 10),
+            #(256, 16, 10),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/sanity/sanity.py
+++ b/frontera/tests/sanity/sanity.py
@@ -1,0 +1,46 @@
+'''
+    Sanity tests.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '1',
+    'xfer_size': '1M',
+    'block_size': '150G',
+    'n_file': '1000000',
+    'bytes_read': '0',
+    'bytes_write': '0',
+    'tree_depth': '0',
+    'sw_time': '5',
+    'iterations': '1',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_sanity',
+        'oclass': 'SX',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 1, 1),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+    {
+        'test_group': 'MDTEST',
+        'test_name': 'mdtest_sanity',
+        'oclass': [('S1', 'SX')],
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (1, 1, 1),
+        ],
+        'env_vars': dict(env_vars),
+        'enabled': True
+    },
+]

--- a/frontera/tests/self_test/self_test.py
+++ b/frontera/tests/self_test/self_test.py
@@ -1,0 +1,50 @@
+'''
+    self_test test cases.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# List of tests
+tests = [
+    {
+        'test_group': 'SELF_TEST',
+        'test_name': 'st_1tomany_cli2srv_inf1',
+        'scale': [
+            # 1to4, (num_servers, num_clients, timeout_minutes)
+            (2, 1, 15),
+            (4, 1, 15),
+            (8, 1, 15),
+            (16, 1, 15),
+            (32, 1, 15),
+            (64, 1, 15),
+            (128, 1, 15),
+            (256, 1, 15),
+            (512, 1, 15),
+        ],
+        'env_vars': {
+            'inflight': 1,
+            'ppc': 1
+        },
+        'enabled': False
+    },
+    {
+        'test_group': 'SELF_TEST',
+        'test_name': 'st_1tomany_cli2srv_inf16',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (2, 1, 15),
+            (4, 1, 15),
+            (8, 1, 15),
+            (16, 1, 15),
+            (32, 1, 15),
+            (64, 1, 15),
+            (128, 1, 15),
+            (256, 1, 15),
+            (512, 1, 15)
+        ],
+        'env_vars': {
+            'inflight': 16,
+            'ppc': 1
+        },
+        'enabled': False
+    },
+]

--- a/frontera/tests/shard/shard.py
+++ b/frontera/tests/shard/shard.py
@@ -1,0 +1,65 @@
+'''
+    Tests with varying shareds.
+    Defines a list 'tests' containing dictionary items of tests.
+'''
+
+# Default environment variables used by each test
+env_vars = {
+    'pool_size': '85G',
+    'chunk_size': '1M',
+    'segments': '1',
+    'xfer_size': None, # placeholder
+    'block_size': '1G',
+    'fpp': '-F',
+    'sw_time': '60',
+    'iterations': '2',
+    'ppc': 32
+}
+
+# List of tests
+tests = [
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy_S2',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (4, 8, 10)
+        ],
+        'oclass': 'S2',
+        'env_vars': dict(env_vars, xfer_size='2M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy_S4',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (6, 12, 10)
+        ],
+        'oclass': 'S4',
+        'env_vars': dict(env_vars, xfer_size='4M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy_S8',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (40, 20, 10)
+        ],
+        'oclass': 'S8',
+        'env_vars': dict(env_vars, xfer_size='8M'),
+        'enabled': False
+    },
+    {
+        'test_group': 'IOR',
+        'test_name': 'ior_easy_S16',
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (18, 36, 15)
+        ],
+        'oclass': 'S16',
+        'env_vars': dict(env_vars, xfer_size='16M'),
+        'enabled': False
+    },
+]


### PR DESCRIPTION
- Add `tests` directory with test configs
  - Each config is a python file with a `tests` list defined
- `run_testlist.py`
  - Add support for passing in the config paths
  - Simplify core logic

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>