### PR TITLE
miscellaneous improvements

### DIFF
--- a/frontera/get_results.py
+++ b/frontera/get_results.py
@@ -781,8 +781,8 @@ class CsvRebuild(CsvBase):
         row["status"]                 = status.get_status_str()
         row["notes"]                  = status.get_notes_str()
 
-def get_stdout_list(result_path, prefix):
-    """Get a list of stdout files for a given prefix.
+def get_output_list(result_path, prefix):
+    """Get a list of output files for a given prefix.
 
     Args:
         result_path (str): Path to the top-level directory.
@@ -790,19 +790,19 @@ def get_stdout_list(result_path, prefix):
             For example: mdtest, ior, rebuild.
 
     Returns:
-        list: List of sorted paths to stdout files.
+        list: List of sorted paths to output files.
     """
-    # Recursively drill down to find each stdout file in each log directory
+    # Recursively drill down to find each output file in each log directory
     # in each directory
     path_obj = Path(result_path)
 
-    output_file_list = sorted(path_obj.rglob(f"*{prefix}_*/log_*/*/stdout*"))
+    output_file_list = sorted(path_obj.rglob(f"*{prefix}_*/log_*/*/output*"))
     if not output_file_list and prefix in result_path:
-        output_file_list = sorted(path_obj.rglob("log_*/*/stdout*"))
+        output_file_list = sorted(path_obj.rglob("log_*/*/output*"))
 
     # In case the log directory itself is passed
     if not output_file_list and prefix in result_path and "log_" in result_path:
-        output_file_list = sorted(path_obj.rglob("stdout*"))
+        output_file_list = sorted(path_obj.rglob("output*"))
 
     if not output_file_list:
         print(f"No {prefix} log files found", flush=True)
@@ -827,7 +827,7 @@ def generate_results(result_dir, prefix, csv_class, csv_path, output_style):
         print(f"ERR {csv_class} is not a subclass of CsvBase", file=sys.stderr)
         return False
 
-    output_file_list = get_stdout_list(result_dir, prefix)
+    output_file_list = get_output_list(result_dir, prefix)
     if not output_file_list:
         return False
 

--- a/frontera/mpi_gen_hostlist.sh
+++ b/frontera/mpi_gen_hostlist.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Generate server and client hostlists from slurm nodes.
+# Expects RUN_DIR, SLURM_JOB_ID, SLURM_JOB_NUM_NODES to be defined.
+#
+
+mpi_target=$1
+num_servers=$2
+num_clients=$3
+
+if [ "${mpi_target}" == "mvapich2" ] || [ "${mpi_target}" == "mpich" ]; then
+    # Use abbreviated hostname
+    srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" | cut -c 1-8 > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
+elif [ "${mpi_target}" == "openmpi" ]; then
+    # Use full hostname
+    srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
+else
+    echo "Unknown mpi_target. Please specify either mvapich2, openmpi, or mpich"
+    exit 1
+fi
+
+# Split into server and client hostlists
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$num_servers > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
+cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$num_clients > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/frontera/mpich_gen_hostlist.sh
+++ b/frontera/mpich_gen_hostlist.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-N_SERVERS=$1
-N_CLIENTS=$2
-
-srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" | cut -c 1-8 > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/frontera/mvapich2_gen_hostlist.sh
+++ b/frontera/mvapich2_gen_hostlist.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-N_SERVERS=$1
-N_CLIENTS=$2
-
-srun -n $SLURM_JOB_NUM_NODES hostname | sed "/$(hostname)/d" | cut -c 1-8 > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/frontera/openmpi_gen_hostlist.sh
+++ b/frontera/openmpi_gen_hostlist.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-N_SERVERS=$1
-N_CLIENTS=$2
-
-srun -n $SLURM_JOB_NUM_NODES hostname > ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist
-sed -i "/$(hostname)/d" ${RUN_DIR}/$SLURM_JOB_ID/daos_all_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | tail -$N_SERVERS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_server_hostlist
-cat ${RUN_DIR}/${SLURM_JOB_ID}/daos_all_hostlist | head -$N_CLIENTS > ${RUN_DIR}/${SLURM_JOB_ID}/daos_client_hostlist

--- a/frontera/sbatch_me.txt
+++ b/frontera/sbatch_me.txt
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-#SBATCH -o %j/stdout.txt        # Name of stdout output file
-#SBATCH -e %j/stderr.txt        # Name of stderr error file
+#SBATCH -o %j/output.txt        # Name of stdout output file
+#SBATCH -e %j/output.txt        # Name of stderr error file
 #SBATCH -A STAR-Intel           # Project Name
 #SBATCH --mail-type=all         # Send email at begin and end of job
 
 mkdir -p ${RUN_DIR}
 
-${DST_DIR}/frontera/tests.sh ${1} |& tee ${RUN_DIR}/${SLURM_JOB_ID}/output.txt
+${DST_DIR}/frontera/tests.sh ${1}
 
 exit ${PIPESTATUS[0]}

--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -140,12 +140,6 @@ function print_separator(){
     printf '%80s\n' | tr ' ' =
 }
 
-function cleanup(){
-    pmsg "Removing temporary files"
-    ${SRUN_CMD} ${DST_DIR}/frontera/cleanup.sh
-    echo "End Time: $(date)"
-}
-
 function collect_test_logs(){
     pmsg "Collecting metrics and logs"
 
@@ -301,12 +295,17 @@ function teardown_test(){
     pmsg "List surviving processes"
     eval "${csh_prefix} -B \"pgrep -a ${PROCESSES}\""
 
-    cleanup
+    pmsg "Removing temporary files"
+    ${SRUN_CMD} ${DST_DIR}/frontera/cleanup.sh
+
+    pmsg "Removing empty core dumps"
+    find ${DUMP_DIR} -type d -empty -print -delete 
 
     pkill -e --signal SIGKILL -P $$
 
     pmsg "End of teardown"
 
+    echo "End Time: $(date)"
     echo "EXIT_MESSAGE : ${exit_message}"
     echo "EXIT_RC      : ${exit_rc}"
     exit ${exit_rc}

--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -405,12 +405,9 @@ function prepare(){
     ${SRUN_CMD} ${DST_DIR}/frontera/create_log_dir.sh
 
     # Generate MPI hostlist
-    if [ "${MPI_TARGET}" == "mvapich2" ]; then
-        ${DST_DIR}/frontera/mvapich2_gen_hostlist.sh ${DAOS_SERVERS} ${DAOS_CLIENTS}
-    elif [ "${MPI_TARGET}" == "openmpi" ]; then
-        ${DST_DIR}/frontera/openmpi_gen_hostlist.sh ${DAOS_SERVERS} ${DAOS_CLIENTS}
-    else
-        ${DST_DIR}/frontera/mpich_gen_hostlist.sh ${DAOS_SERVERS} ${DAOS_CLIENTS}
+    ${DST_DIR}/frontera/mpi_gen_hostlist.sh ${MPI_TARGET} ${DAOS_SERVERS} ${DAOS_CLIENTS}
+    if [ $? -ne 0 ]; then
+        teardown_test "Failed to generate mpi hostlist" 1
     fi
 
     # Use the first server as the access point

--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -533,8 +533,6 @@ function daos_cont_create(){
 
     if [ $? -ne 0 ]; then
         teardown_test "Daos container create FAIL" 1
-    else
-        pmsg "Daos container create SUCCESS"
     fi
 }
 
@@ -543,8 +541,6 @@ function daos_cont_query(){
     local pool="${1:-${POOL_UUID}}"
     local cont="${2:-${CONT_UUID}}"
     local host=$(head -n 1 ${CLIENT_HOSTLIST_FILE})
-
-    pmsg "Querying container ${pool}:${cont}"
 
     local daos_cmd="daos container query --pool=${pool} --cont=${cont}"
     local cmd="clush -w ${host} --command_timeout ${CMD_TIMEOUT} -S
@@ -561,9 +557,7 @@ function daos_cont_query(){
     eval ${cmd}
 
     if [ $? -ne 0 ]; then
-        teardown_test "Daos container query FAIL" 1
-    else
-        pmsg "Daos container query SUCCESS"
+        teardown_test "daos container query FAIL" 1
     fi
 }
 


### PR DESCRIPTION
- Remove empty core_dump directories to reduce log clutter
- When calling dmg system query, teardown if the state is not Joined
- Consolidate mpich_gen_hostlist.sh, mvapich2_gen_hostlist.sh, openmpi_gen_hostlist.s into mpi_gen_hostlist.sh
- combine stderr.txt, stdout.txt, and output.txt into just output.txt
- remove some redundant print statements
- enhance server startup logic - Instead of retrying some number of times, retry every 15s, but up to
   300s total. Also print the elapsed time for future tweaking of timeouts.