### PR TITLE
miscellaneous improvements

### DIFF
--- a/frontera/cleanup.sh
+++ b/frontera/cleanup.sh
@@ -5,3 +5,5 @@
 
 rm -rf /dev/shm/*
 rm -rf /tmp/daos*log
+rm -rf /tmp/daos_agent
+rm -rf /tmp/daos_server

--- a/frontera/create_log_dir.sh
+++ b/frontera/create_log_dir.sh
@@ -7,7 +7,7 @@ LOG_DIR=${RUN_DIR}/${SLURM_JOB_ID}/logs/$(hostname)
 
 mkdir -p ${LOG_DIR}
 
-pushd /tmp
+pushd /tmp > /dev/null
 rm -f daos_logs
 ln -s ${LOG_DIR} daos_logs
-popd
+popd > /dev/null

--- a/frontera/daos_server.yml
+++ b/frontera/daos_server.yml
@@ -21,6 +21,9 @@ engines:
   - FI_OFI_RXM_USE_SRX=1
   - DTX_AGG_THD_CNT=16777216 # max count
   - DTX_AGG_THD_AGE=700      # max age
+  - SWIM_PROTOCOL_PERIOD_LEN=2000
+  - SWIM_SUSPECT_TIMEOUT=19000
+  - SWIM_PING_TIMEOUT=1900
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0

--- a/frontera/get_results.py
+++ b/frontera/get_results.py
@@ -861,7 +861,7 @@ def get_output_list(result_path, prefix):
     return output_file_list
 
 def generate_results(result_dir, prefix, csv_class, csv_path, output_style):
-    """Generate a CSV from a directry containing results.
+    """Generate a CSV from a directory containing results.
 
     Args:
         result_dir (str): Path the results directory.


### PR DESCRIPTION
- add --filter option to run_testlist.py
  Allow filtering by environment values, where space means OR and comma
  means AND, similar to avocado
  Example: --filter "oclass=SX,daos_servers=1 daos_servers=2,daos_clients=16"
  Useful for running a subset of tests without having to modify config
  files.

- tests.sh
  - setup daos paths and libraries in a function so we can run
    against multiple DAOS installations in one job
  - make some more params configurable
  - add optional IOR_WAIT_TIME to wait between phases for ior and mdtest
  - minor bug fixes
  - when waiting for servers, sleep AFTER the first try for tighter
    bounds
  - silence stdout from pushd and popd

- increase SWIM timeouts by default, per recommendation

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>