### PR TITLE
misc improvements

### DIFF
--- a/frontera/README.md
+++ b/frontera/README.md
@@ -13,6 +13,7 @@ against an older version of DAOS.
 | DAOS Commit   | Newest Compatible Script Commit |
 | ------------- | ------------------------------- |
 | master        | master |
+| v1.3.106-tb   | master |
 | v1.3.105-tb   | master |
 | v1.3.104-tb   | master |
 | v1.3.103-tb   | master |


### PR DESCRIPTION
- Update frontera/README.md
- tests.sh
  - allow pool properties to be configured and nullable
  - configurable IOR_ITER_DELAY (-d)
  - rename IOR_WAIT_TIME to IOR_PHASE_DELAY
  - when running both IOR write and read, don't use -W since read phase
    will handle verfication

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>