### PR TITLE
ior dedup workaround patch

### DIFF
--- a/frontera/patches/ior_dedup_workaround.patch
+++ b/frontera/patches/ior_dedup_workaround.patch
@@ -1,0 +1,39 @@
+diff --git a/src/ior.c b/src/ior.c
+index a4af7b3..e591b89 100755
+--- a/src/ior.c
++++ b/src/ior.c
+@@ -1219,7 +1219,7 @@ static void TestIoSys(IOR_test_t *test)
+                           (&params->timeStampSignatureValue, 1, MPI_UNSIGNED, 0,
+                            testComm), "cannot broadcast start time value");
+ 
+-                generate_memory_pattern((char*) ioBuffers.buffer, params->transferSize, params->setTimeStampSignature, pretendRank, params->dataPacketType);
++                generate_memory_pattern((char*) ioBuffers.buffer, params->transferSize, params->setTimeStampSignature, 0, params->dataPacketType);
+ 
+                 /* use repetition count for number of multiple files */
+                 if (params->multiFile)
+@@ -1635,7 +1635,7 @@ static IOR_offset_t WriteOrReadSingle(IOR_offset_t offset, int pretendRank, IOR_
+   if (access == WRITE) {
+           /* fills each transfer with a unique pattern
+            * containing the offset into the file */
+-          update_write_memory_pattern(offset, ioBuffers->buffer, transfer, test->setTimeStampSignature, pretendRank, test->dataPacketType);
++          update_write_memory_pattern(offset, ioBuffers->buffer, transfer, test->setTimeStampSignature, 0, test->dataPacketType);
+           amtXferred = backend->xfer(access, fd, buffer, transfer, offset, test->backend_options);
+           if (amtXferred != transfer)
+                   ERR("cannot write to file");
+@@ -1658,14 +1658,14 @@ static IOR_offset_t WriteOrReadSingle(IOR_offset_t offset, int pretendRank, IOR_
+           amtXferred = backend->xfer(access, fd, buffer, transfer, offset, test->backend_options);
+           if (amtXferred != transfer)
+                   ERR("cannot read from file write check");
+-          *errors += CompareData(buffer, transfer, *transferCount, test, offset, pretendRank, WRITECHECK);
++          *errors += CompareData(buffer, transfer, *transferCount, test, offset, 0, WRITECHECK);
+   } else if (access == READCHECK) {
+           ((long long int*) buffer)[0] = ~((long long int*) buffer)[0]; // changes the buffer, no memset to reduce the memory pressure
+           amtXferred = backend->xfer(access, fd, buffer, transfer, offset, test->backend_options);
+           if (amtXferred != transfer){
+             ERR("cannot read from file");
+           }
+-          *errors += CompareData(buffer, transfer, *transferCount, test, offset, pretendRank, READCHECK);
++          *errors += CompareData(buffer, transfer, *transferCount, test, offset, 0, READCHECK);
+   }
+   return amtXferred;
+ }

--- a/frontera/run_build.sh
+++ b/frontera/run_build.sh
@@ -202,6 +202,11 @@ if [ ! -z "${IOR_COMMIT}" ]; then
     git checkout -b "${IOR_COMMIT}" "${IOR_COMMIT}"
 fi
 
+# Apply patch to make all processes write the same data.
+# This is needed to reduce pool space usage so a larger number of clients can be used.
+cp ${CURRENT_DIR}/patches/ior_dedup_workaround.patch .
+git apply ior_dedup_workaround.patch
+
 print_repo_info |& tee -a ${BUILD_DIR}/${TIMESTAMP}/repo_info.txt
 ./bootstrap
 ./configure --prefix=${LATEST_DAOS}/ior${MPI_SUFFIX} \


### PR DESCRIPTION
IOR patch to make all processes write the same data buffer.
This reduces per target space usage and allows runs with more client
processes.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>