### PR TITLE
remove read phase from mdtest easy

### DIFF
--- a/frontera/tests.sh
+++ b/frontera/tests.sh
@@ -99,7 +99,7 @@ echo "POOL_SIZE       : ${POOL_SIZE}"
 echo "FPP             : ${FPP}"
 echo "MPI_TARGET      : ${MPI_TARGET}"
 echo "IOR_PHASE_DELAY : ${IOR_PHASE_DELAY}"
-echo "EXTRA_MDTEST_PARAMS : ${EXTRA_MDTEST_PARAMS}"
+echo "MDTEST_FLAGS    : ${MDTEST_FLAGS}"
 echo
 echo "Test runner hostname: ${HOSTNAME}"
 echo
@@ -866,7 +866,7 @@ function run_cart_test_group_np_srv(){
 function run_mdtest(){
     pmsg "CMD: Starting MDTEST..."
 
-    local params="-F -P -G 27 -N 1 -d / -p 10 -Y -v ${EXTRA_MDTEST_PARAMS}"
+    local params="-F -P -G 27 -N 1 -d / -p 10 -Y -v ${MDTEST_FLAGS}"
 
     local mdtest_cmd="${MDTEST_BIN}
         ${params}

--- a/frontera/tests/basic/mdtest_easy.py
+++ b/frontera/tests/basic/mdtest_easy.py
@@ -8,7 +8,7 @@ env_vars = {
     'pool_size': '85G',
     'chunk_size': '1M',
     'n_file': '10000000',
-    'extra_mdtest_params': '-u -L',
+    'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
     'bytes_write': '0',
     'sw_time': '60',

--- a/frontera/tests/basic/mdtest_hard.py
+++ b/frontera/tests/basic/mdtest_hard.py
@@ -8,7 +8,7 @@ env_vars = {
     'pool_size': '85G',
     'chunk_size': '1M',
     'n_file': '10000000',
-    'extra_mdtest_params': '-t -X',
+    'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
     'bytes_write': '3901',
     'sw_time': '30',

--- a/frontera/tests/ec_vs_rf0/mdtest_easy.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_easy.py
@@ -9,7 +9,7 @@ env_vars = {
     'chunk_size': None, # placeholder
     'ec_cell_size': '1048576',
     'n_file': '10000000',
-    'extra_mdtest_params': '-u -L',
+    'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
     'bytes_write': '0',
     'sw_time': '30',

--- a/frontera/tests/ec_vs_rf0/mdtest_hard.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_hard.py
@@ -9,7 +9,7 @@ env_vars = {
     'chunk_size': None, # placeholder
     'ec_cell_size': '1048576',
     'n_file': '10000000',
-    'extra_mdtest_params': '-t -X',
+    'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
     'bytes_write': '3901',
     'sw_time': '30',

--- a/frontera/tests/ec_vs_rf0_simple/mdtest_easy.py
+++ b/frontera/tests/ec_vs_rf0_simple/mdtest_easy.py
@@ -9,7 +9,7 @@ env_vars = {
     'chunk_size': None, # placeholder
     'ec_cell_size': '1048576',
     'n_file': '10000000',
-    'extra_mdtest_params': '-u -L',
+    'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
     'bytes_write': '0',
     'sw_time': '30',

--- a/frontera/tests/ec_vs_rf0_simple/mdtest_hard.py
+++ b/frontera/tests/ec_vs_rf0_simple/mdtest_hard.py
@@ -9,7 +9,7 @@ env_vars = {
     'chunk_size': None, # placeholder
     'ec_cell_size': '1048576',
     'n_file': '10000000',
-    'extra_mdtest_params': '-t -X',
+    'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
     'bytes_write': '3901',
     'sw_time': '30',

--- a/frontera/tests/repl/mdtest_easy.py
+++ b/frontera/tests/repl/mdtest_easy.py
@@ -8,7 +8,7 @@ env_vars = {
     'pool_size': '85G',
     'chunk_size': '1M',
     'n_file': '10000000',
-    'extra_mdtest_params': '-u -L',
+    'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
     'bytes_write': '0',
     'sw_time': '60',

--- a/frontera/tests/repl/mdtest_hard.py
+++ b/frontera/tests/repl/mdtest_hard.py
@@ -8,7 +8,7 @@ env_vars = {
     'pool_size': '85G',
     'chunk_size': '1M',
     'n_file': '10000000',
-    'extra_mdtest_params': '-t -X',
+    'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
     'bytes_write': '3901',
     'sw_time': '60',

--- a/frontera/tests/sanity/mdtest.py
+++ b/frontera/tests/sanity/mdtest.py
@@ -8,7 +8,7 @@ env_vars = {
     'pool_size': '85G',
     'chunk_size': '1M',
     'n_file': '10000000',
-    'extra_mdtest_params': '-u -L',
+    'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
     'bytes_write': '0',
     'sw_time': '5',


### PR DESCRIPTION
Read for mdtest easy is not useful.
Also rename extra_mdtest_params -> mdtest_flags.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>