### PR TITLE
fix ec_vs_rf ec_cell_size

### DIFF
--- a/frontera/tests/ec_vs_rf0/ior_easy.py
+++ b/frontera/tests/ec_vs_rf0/ior_easy.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'segments': '1',
     'xfer_size': None, # placeholder
     'block_size': '150G',
@@ -69,6 +68,7 @@ tests = [
         'test_group': 'IOR',
         'test_name': 'ior_easy',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk, xfer_size=_xfer),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0/ior_hard.py
+++ b/frontera/tests/ec_vs_rf0/ior_hard.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'segments': '2000000',
     'xfer_size': '47008',
     'block_size': '47008',
@@ -69,6 +68,7 @@ tests = [
         'test_group': 'IOR',
         'test_name': 'ior_hard',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0/mdtest_easy.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_easy.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'n_file': '10000000',
     'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
@@ -69,6 +68,7 @@ tests = [
         'test_group': 'MDTEST',
         'test_name': 'mdtest_easy',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0/mdtest_hard.py
+++ b/frontera/tests/ec_vs_rf0/mdtest_hard.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'n_file': '10000000',
     'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
@@ -69,6 +68,7 @@ tests = [
         'test_group': 'MDTEST',
         'test_name': 'mdtest_hard',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0_simple/ior_easy.py
+++ b/frontera/tests/ec_vs_rf0_simple/ior_easy.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'segments': '1',
     'xfer_size': None, # placeholder
     'block_size': '150G',
@@ -63,6 +62,7 @@ tests = [
         'test_group': 'IOR',
         'test_name': 'ior_easy',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk, xfer_size=_xfer),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0_simple/ior_hard.py
+++ b/frontera/tests/ec_vs_rf0_simple/ior_hard.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'segments': '2000000',
     'xfer_size': '47008',
     'block_size': '47008',
@@ -63,6 +62,7 @@ tests = [
         'test_group': 'IOR',
         'test_name': 'ior_hard',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0_simple/mdtest_easy.py
+++ b/frontera/tests/ec_vs_rf0_simple/mdtest_easy.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'n_file': '10000000',
     'mdtest_flags': '-C -T -r -u -L',
     'bytes_read': '0',
@@ -63,6 +62,7 @@ tests = [
         'test_group': 'MDTEST',
         'test_name': 'mdtest_easy',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True

--- a/frontera/tests/ec_vs_rf0_simple/mdtest_hard.py
+++ b/frontera/tests/ec_vs_rf0_simple/mdtest_hard.py
@@ -7,7 +7,6 @@
 env_vars = {
     'pool_size': '85G',
     'chunk_size': None, # placeholder
-    'ec_cell_size': '1048576',
     'n_file': '10000000',
     'mdtest_flags': '-C -T -r -E -t -X',
     'bytes_read': '3901',
@@ -63,6 +62,7 @@ tests = [
         'test_group': 'MDTEST',
         'test_name': 'mdtest_hard',
         'oclass': _oclass,
+        'ec_cell_size': '1048576',
         'scale': _scale,
         'env_vars': dict(env_vars, chunk_size=_chunk),
         'enabled': True


### PR DESCRIPTION
ec_cell_size is treated as a variant so it should be a test param, not
env var

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>