### PR TITLE
reduce output clutter

### DIFF
--- a/frontera/run_testlist.py
+++ b/frontera/run_testlist.py
@@ -122,7 +122,7 @@ class TestList(object):
     def _expand_default_test_params(self, test_params):
         for param, default in [
                 ('oclass', ['']),
-                ('ec_cell_size', ['1048576'])]:
+                ('ec_cell_size', [''])]:
             if param not in test_params:
                 # Set default value
                 test_params[param] = default


### PR DESCRIPTION
- Don't print rf and ec cell size, since the command string contains it
- Don't explicitly set cont rf and ec cell size to the default

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>