### PR TITLE
Stop using pool/cont uuids

### DIFF
--- a/frontera/README.md
+++ b/frontera/README.md
@@ -10,13 +10,16 @@ Not all versions of these scripts are compatible with all versions of DAOS.
 It may be necessary to use a specific commit when building or running tests
 against an older version of DAOS.
 
-| DAOS Commit   | Newest Compatible Script Commit |
-| ------------- | ------------------------------- |
-| master        | master |
-| v1.3.106-tb   | master |
-| v1.3.105-tb   | master |
-| v1.3.104-tb   | master |
-| v1.3.103-tb   | master |
-| v1.3.102-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |
-| v1.3.101-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |
-| v1.2.0        | 9dc82ffad5394ef0fac70bdc6563adbae58d522c  |
+| DAOS Commit   | Newest Compatible Script Commit          | Notes        |
+| ------------- | ---------------------------------------- | ------------ |
+| master        | master                                   |              |
+| v2.0.2        | master                                   |              |
+| v2.0.1        | master                                   |              |
+| v2.0.0        | master                                   |              |
+| v1.3.106-tb   | master                                   |              |
+| v1.3.105-tb   | d4afa5fe2150a5a25ad0a1f78cbe685b78a7b4d1 | Need new IOR for label support |
+| v1.3.104-tb   | d4afa5fe2150a5a25ad0a1f78cbe685b78a7b4d1 | Need new IOR for label support |
+| v1.3.103-tb   | d4afa5fe2150a5a25ad0a1f78cbe685b78a7b4d1 | Need new IOR for label support |
+| v1.3.102-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c |              |
+| v1.3.101-tb   | 9dc82ffad5394ef0fac70bdc6563adbae58d522c |              |
+| v1.2.0        | 9dc82ffad5394ef0fac70bdc6563adbae58d522c |              |

--- a/frontera/tests/sanity/rebuild.py
+++ b/frontera/tests/sanity/rebuild.py
@@ -32,4 +32,21 @@ tests = [
             block_size='100M'),
         'enabled': True
     },
+    {
+        'test_group': 'SWIM',
+        'test_name': 'rebuild_pool_multi_sanity',
+        'oclass': 'EC_2P1GX',
+        'ec_cell_size': 65536, # 1M chunk / 16
+        'scale': [
+            # (num_servers, num_clients, timeout_minutes)
+            (4, 1, 5),
+        ],
+        'env_vars': dict(
+            env_vars,
+            cont_rf=1,
+            block_size='100M',
+            pool_size='256MiB',
+            number_of_pools='5'),
+        'enabled': False
+    },
 ]


### PR DESCRIPTION
Stop referring to pool/cont uuids and instead always use labels.
Labels are more human-readable and eventually it will not be possible to
create a pool/cont with a user-generated uuid.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>