### PR TITLE
frontera: config options for tcp and sockets

### DIFF
--- a/frontera/daos_server.yml
+++ b/frontera/daos_server.yml
@@ -6,6 +6,8 @@ name: daos_server
 nr_hugepages: 4096
 port: 10001
 provider: ofi+verbs;ofi_rxm
+#provider: ofi+tcp;ofi_rxm
+#provider: ofi+sockets
 crt_timeout: 180
 crt_ctx_share_addr: 0
 engines:
@@ -25,6 +27,9 @@ engines:
   - SWIM_PROTOCOL_PERIOD_LEN=2000
   - SWIM_SUSPECT_TIMEOUT=19000
   - SWIM_PING_TIMEOUT=1900
+  # For sockets
+  #- FI_SOCKETS_MAX_CONN_RETRY=1
+  #- FI_SOCKETS_CONN_TIMEOUT=2000
   fabric_iface: ib0
   fabric_iface_port: 31416
   first_core: 0

--- a/frontera/env_daos
+++ b/frontera/env_daos
@@ -3,11 +3,21 @@ export FI_OFI_RXM_USE_SRX=1
 export FI_MR_CACHE_MONITOR=disabled
 export D_LOG_FILE=/tmp/daos_logs/daos_client.log
 export D_LOG_MASK=ERR
-export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
-export OFI_INTERFACE=ib0
-export OFI_DOMAIN=mlx5_0
 export DAOS_AGENT_DRPC_DIR=/tmp/daos_agent
 export DAOS_DISABLE_REQ_FWD=1
+export OFI_INTERFACE=ib0
+
+# For verbs
+export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"
+export OFI_DOMAIN=mlx5_0
+
+# For tcp
+#export CRT_PHY_ADDR_STR="ofi+tcp;ofi_rxm"
+#export OFI_DOMAIN=ib0
+
+# For sockets
+#export CRT_PHY_ADDR_STR="ofi+sockets"
+#export OFI_DOMAIN=ib0
 
 LOCATION=$1
 

--- a/frontera/get_results.py
+++ b/frontera/get_results.py
@@ -187,6 +187,32 @@ def get_num_targets(output_file_path, slurm_job_id):
         return None
     return match.group(1)
 
+def get_provider(output_file_path, slurm_job_id):
+    """Get the provider from the server config.
+
+    Args:
+        output_file_path (str): path to the log output.
+        slurm_job_id (str): the slurm job id.
+
+    Returns:
+        str: the number of targets
+             None on failure.
+
+    """
+    if not slurm_job_id:
+        return None
+
+    dir_name = dirname(output_file_path)
+
+    config_path = join(dir_name, "daos_server.yml")
+    config = read_file(config_path)
+    if not config:
+        return None
+    match = re.search("^provider: (.*)$", config, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1)
+
 def get_mdtest_metric_max(metric, output):
     """Get the "max" for an mdtest metric.
 
@@ -500,6 +526,7 @@ class CsvIor(CsvBase):
             "start_time":   "Date",
             "end_time":     "End",
             "daos_commit":  "Commit",
+            "provider":     "Provider",
             "oclass":       "Oclass",
             "num_servers":  "Num_Servers",
             "num_targets":  "Num Targets",
@@ -518,7 +545,7 @@ class CsvIor(CsvBase):
             "write_gib":    "Write (GiB/sec)",
             "read_gib":     "Read (GiB/sec)"
         }
-        row_order = ["test_case", "start_time", "daos_commit", "oclass",
+        row_order = ["test_case", "start_time", "daos_commit", "provider", "oclass",
                      "num_servers", "num_clients", "ppc",
                      "write_gib", "read_gib",
                      "notes", "status"]
@@ -553,6 +580,7 @@ class CsvIor(CsvBase):
 
         row["daos_commit"] = get_daos_commit(file_path, row["slurm_job_id"])
         row["num_targets"] = get_num_targets(file_path, row["slurm_job_id"])
+        row["provider"]    = get_provider(file_path, row["slurm_job_id"])
         row["write_gib"]   = format_float(wr_gib)
         row["read_gib"]    = format_float(rd_gib)
         row["status"]      = status.get_status_str()
@@ -576,6 +604,7 @@ class CsvMdtest(CsvBase):
             "start_time":   "Date",
             "end_time":     "End",
             "daos_commit":  "Commit",
+            "provider":     "Provider",
             "oclass":       "Oclass",
             "dir_oclass":   "Dir Oclass",
             "num_servers":  "Num Servers",
@@ -594,7 +623,7 @@ class CsvMdtest(CsvBase):
             "read_kops":    "read(Kops/sec)",
             "remove_kops":  "remove(Kops/sec)"
         }
-        row_order = ["test_case", "start_time", "daos_commit", "oclass",
+        row_order = ["test_case", "start_time", "daos_commit", "provider", "oclass",
                      "num_servers", "num_clients", "ppc", "create_kops",
                      "stat_kops", "read_kops", "remove_kops",
                      "notes", "status"]
@@ -649,6 +678,7 @@ class CsvMdtest(CsvBase):
 
         row["daos_commit"] = get_daos_commit(file_path, row["slurm_job_id"])
         row["num_targets"] = get_num_targets(file_path, row["slurm_job_id"])
+        row["provider"]    = get_provider(file_path, row["slurm_job_id"])
         row["status"]      = status.get_status_str()
         row["notes"]       = status.get_notes_str()
 


### PR DESCRIPTION
- parse provider in get_results.py
- add placeholder tcp and sockets env vars

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>