### PR TITLE
endeavour: remove duplicate cleanup_server call

### DIFF
--- a/edv/test_scripts/server/run_server.sh
+++ b/edv/test_scripts/server/run_server.sh
@@ -10,7 +10,7 @@ export HOSTLIST="hostlists/srv_hostlist${NSERVER}"
 
 cd ${SRVDIR}
 pwd
-clush --hostfile=${ALLHOST} "export TB=${TB}; export SRVDIR=${SRVDIR}; cd ${SRVDIR}; ./clean_server.sh; ./clean_server.sh"
+clush --hostfile=${ALLHOST} "export TB=${TB}; export SRVDIR=${SRVDIR}; cd ${SRVDIR}; ./clean_server.sh"
 sleep 15
 echo "Clean - DONE"
 clush --hostfile=${ALLHOST} "export TB=${TB}; export SRVDIR=${SRVDIR}; cd ${SRVDIR}; ./run_storage_scan.sh"


### PR DESCRIPTION
In the server script run_server.sh, we call three other scripts to
clean up the servers, run the storage scan and start the servers.
We call clean_server.sh twice.  We should only call clean_server.sh
once.

Signed-off-by: James Nunez <james.nunez@intel.com>