### PR TITLE
endeavour: clean up scripts

### DIFF
--- a/edv/test_scripts/client/scripts/client_env.sh
+++ b/edv/test_scripts/client/scripts/client_env.sh
@@ -38,10 +38,6 @@ export PATH=/usr/local/ofed/CURRENT/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/ofed/CURRENT/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/ofed/CURRENT/lib64/libibverbs:$LD_LIBRARY_PATH
 
-# Use crt's fuse libraries since CentOS8 has a very old version
-export PATH=/opt/crtdc/fuse3/bin:$PATH
-export LD_LIBRARY_PATH=/opt/crtdc/fuse3/lib64:$LD_LIBRARY_PATH
-
 daospath=/$DAOS_INSTALL
 prereqpath=/$DAOS_INSTALL/prereq/release
 
@@ -72,6 +68,6 @@ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/
 
 export CPATH=${daospath}/include/:$CPATH
 
-# FUSE3
+# FUSE3 - Use crt's fuse libraries since CentOS8 has an old version
 export PATH=/opt/crtdc/fuse3/bin:$PATH
 export LD_LIBRARY_PATH=/opt/crtdc/fuse3/lib64:$LD_LIBRARY_PATH

--- a/edv/test_scripts/client/scripts/run_client.sh
+++ b/edv/test_scripts/client/scripts/run_client.sh
@@ -38,8 +38,6 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-ls -al /panfs/users/rpadma2/apps/${MPI}/lammps
-
 echo "Sourcing env"
 if [[ "$TEST" =~ "EFISPEC" ]]; then
   . /opt/intel/oneAPI/latest/setvars.sh
@@ -69,12 +67,12 @@ which daos_agent
 echo
 
 echo "Cleaning Agent"
-clush --hostfile=${CLI_HOSTLIST} "export TB=$TB; export RUNDIR=${RUNDIR}; cd ${RUNDIR}/scripts; source client_env.sh; ./clean_agent.sh"
+clush --hostfile=${CLI_HOSTLIST} "export TB=$TB; export RUNDIR=${RUNDIR}; cd ${RUNDIR}/scripts; ./clean_agent.sh"
 sleep 5
 echo
 
 echo "Starting Agent"
-clush --hostfile=${CLI_HOSTLIST} "export TB=$TB; export RUNDIR=${RUNDIR}; cd ${RUNDIR}/scripts; source client_env.sh; ./start_agent.sh" &
+clush --hostfile=${CLI_HOSTLIST} "export TB=$TB; export RUNDIR=${RUNDIR}; cd ${RUNDIR}/scripts; ./start_agent.sh" &
 sleep 5
 echo
 
@@ -134,7 +132,7 @@ fi
 
 if [ "$MOUNT_DFUSE" == "1" ]; then
   echo "Mounting Dfuse"
-  clush --hostfile=${CLI_HOSTLIST} "export TB=${TB}; export RUNDIR=${RUNDIR}; export PLABEL=${PLABEL}; export CLABEL=${CLABEL}; export MOUNTDIR=${MOUNTDIR}; export DFUSECACHE=${DFUSECACHE}; ${RUNDIR}/scripts/mount_dfuse.sh"
+  clush --hostfile=${CLI_HOSTLIST} "export RUNDIR=${RUNDIR}; export PLABEL=${PLABEL}; export CLABEL=${CLABEL}; export MOUNTDIR=${MOUNTDIR}; export DFUSECACHE=${DFUSECACHE}; ${RUNDIR}/scripts/mount_dfuse.sh"
 
   if [[ ! -d ${MOUNTDIR} ]]; then
     echo Dfuse mount unsuccessful!!

--- a/edv/test_scripts/client/scripts/start_agent.sh
+++ b/edv/test_scripts/client/scripts/start_agent.sh
@@ -6,5 +6,3 @@ mkdir -p ${DAOS_AGENT_DRPC_DIR}
 rm -f daos_server.attach_info_tmp
 export HWLOC_HIDE_ERRORS=1
 daos_agent -o ${RUNDIR}/scripts/daos_agent-${USER}.yml &
-rm -rf /tmp/daos_m/$USER
-mkdir -p /tmp/daos_m/$USER


### PR DESCRIPTION
The following modifications were made to the Endeavour scripts:

1. In run_client.sh, we export the TB variable when calling
   mount_defuse.sh. mount_dfuse.sh doesn't use the TB variable.
   Thus, we can remove the export of the TB variable when calling
   mount_defuse.sh.
2. Both clean_agents.sh and start_agent.sh source client_env.sh.
   The script run_client.sh sources client_env.sh in the clush
   calls to clean_agents.sh and start_agent.sh. We don't need to
   source client_env.sh in the clush call.
3. In run_client.sh, we call “ls -al /panfs/users/${USER}/apps/${MPI}/lammps”
   no matter what application is being executed. We can remove this
   call to 'ls'.
4. The script start_agent.sh removes and then creates the DAOS mount
   point. Removing and creating the mount point doesn't have anything
   to do with starting the agent and should be removed. The run_clientsh
   script removes and creates the DAOS mount point.
5. We can remove the duplicate calls to adding FUSE to the PATH
   and LD_LIBRARY_PATH variables.

Signed-off-by: James Nunez <james.nunez@intel.com>