### PR TITLE
endeavour: create collection of logs utility

### DIFF
--- a/edv/test_scripts/client/scripts/collect_logs.sh
+++ b/edv/test_scripts/client/scripts/collect_logs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Collect logs from the DAOS clients and servers
+# This script needs the following environment variables:
+# RUNDIR, NSERVER, NCLIENT, RESULTDIR, TB
+
+echo START collect logs
+date
+
+export SRV_HOSTLIST="${RUNDIR}/../server/hostlists/srv_hostlist${NSERVER}"
+export CLI_HOSTLIST="${RUNDIR}/hostlists/cli_hostlist${NCLIENT}"
+
+rm -rf ${RESULTDIR}/clientlogs
+mkdir -p ${RESULTDIR}/clientlogs
+
+echo
+echo "Copying clientlogs"
+echo
+
+echo clush --hostfile=${CLI_HOSTLIST} "mkdir -p ${RESULTDIR}/clientlogs/\`hostname\`; cp /tmp/daos_agent-${USER}/daos_client.log ${RESULTDIR}/clientlogs/\`hostname\`/"
+
+clush --hostfile=${CLI_HOSTLIST} "mkdir -p ${RESULTDIR}/clientlogs/\`hostname\`; cp /tmp/daos_agent-${USER}/daos_client.log ${RESULTDIR}/clientlogs/\`hostname\`/"
+
+echo
+echo "Copying serverlogs"
+echo
+
+rm -rf ${RESULTDIR}/serverlogs
+mkdir -p ${RESULTDIR}/serverlogs
+chmod 777 ${RESULTDIR}/serverlogs
+
+echo "clush --user=daos_server --hostfile=${SRV_HOSTLIST} \"export TB=${TB}; cd ${RUNDIR}/../server; source srv_env.sh; daos_metrics -S 0 --csv > /tmp/daos_metrics_0.csv; daos_metrics -S 1 --csv > /tmp/daos_metrics_1.csv; dmesg > /tmp/daos_dmesg.txt\""
+
+clush --user=daos_server --hostfile=${SRV_HOSTLIST} "export TB=${TB}; cd ${RUNDIR}/../server; source srv_env.sh; daos_metrics -S 0 --csv > /tmp/daos_metrics_0.csv; daos_metrics -S 1 --csv > /tmp/daos_metrics_1.csv; dmesg > /tmp/daos_dmesg.txt"
+
+echo "clush --user=daos_server --hostfile=${SRV_HOSTLIST} \"mkdir -p ${RESULTDIR}/serverlogs/\`hostname\`; cp /tmp/daos_*.* ${RESULTDIR}/serverlogs/\`hostname\`/; chmod -R 777 ${RESULTDIR}/serverlogs/\`hostname\`/\""
+
+clush --user=daos_server --hostfile=${SRV_HOSTLIST} "mkdir -p ${RESULTDIR}/serverlogs/\`hostname\`; cp /tmp/daos_*.* ${RESULTDIR}/serverlogs/\`hostname\`/; chmod -R 777 ${RESULTDIR}/serverlogs/\`hostname\`/"
+
+echo END collect logs
+date
+

--- a/edv/test_scripts/client/scripts/run_client.sh
+++ b/edv/test_scripts/client/scripts/run_client.sh
@@ -246,26 +246,11 @@ echo Test Complete
 date
 echo
 
+# Copy DAOS client and server logs
+echo "Copying logs"
 echo
-echo "Copying clientlogs"
+${RUNDIR}/scripts/collect_logs.sh
 echo
-
-rm -rf ${RESULTDIR}/clientlogs
-mkdir -p ${RESULTDIR}/clientlogs
-
-clush --hostfile=${CLI_HOSTLIST} "mkdir -p ${RESULTDIR}/clientlogs/\`hostname\`; cp /tmp/daos_agent-${USER}/daos_client.log ${RESULTDIR}/clientlogs/\`hostname\`/"
-
-echo
-echo "Copying serverlogs"
-echo
-
-rm -rf ${RESULTDIR}/serverlogs
-mkdir -p ${RESULTDIR}/serverlogs
-chmod 777 ${RESULTDIR}/serverlogs
-
-clush --user=daos_server --hostfile=${SRV_HOSTLIST} "export TB=${TB}; cd ${RUNDIR}/../server; source srv_env.sh; daos_metrics -S 0 --csv > /tmp/daos_metrics_0.csv; daos_metrics -S 1 --csv > /tmp/daos_metrics_1.csv; dmesg > /tmp/daos_dmesg.txt"
-
-clush --user=daos_server --hostfile=${SRV_HOSTLIST} "mkdir -p ${RESULTDIR}/serverlogs/\`hostname\`; cp /tmp/daos_*.* ${RESULTDIR}/serverlogs/\`hostname\`/; chmod -R 777 ${RESULTDIR}/serverlogs/\`hostname\`/"
 
 echo Files after run
 date

--- a/edv/test_scripts/client/scripts/run_client_resnet.sh
+++ b/edv/test_scripts/client/scripts/run_client_resnet.sh
@@ -187,26 +187,11 @@ dmg -o ${RUNDIR}/scripts/daos_control.yml pool query $PLABEL
 #	fi
 #done
 
+# Copy DAOS client and server logs
+echo "Copying logs"
 echo
-echo "Copying clientlogs"
+${RUNDIR}/scripts/collect_logs.sh
 echo
-
-rm -rf ${RESULTDIR}/clientlogs
-mkdir -p ${RESULTDIR}/clientlogs
-
-clush --hostfile=${CLI_HOSTLIST} "mkdir -p ${RESULTDIR}/clientlogs/\`hostname\`; cp /tmp/daos_agent-${USER}/daos_client.log ${RESULTDIR}/clientlogs/\`hostname\`/"
-
-echo
-echo "Copying serverlogs"
-echo
-
-rm -rf ${RESULTDIR}/serverlogs
-mkdir -p ${RESULTDIR}/serverlogs
-chmod 777 ${RESULTDIR}/serverlogs
-
-clush --user=daos_server --hostfile=${SRV_HOSTLIST} "export TB=${TB}; cd ${RUNDIR}/../server; source srv_env.sh; daos_metrics -S 0 --csv > /tmp/daos_metrics_0.csv; daos_metrics -S 1 --csv > /tmp/daos_metrics_1.csv; dmesg > /tmp/daos_dmesg.txt"
-
-clush --user=daos_server --hostfile=${SRV_HOSTLIST} "mkdir -p ${RESULTDIR}/serverlogs/\`hostname\`; cp /tmp/daos_*.* ${RESULTDIR}/serverlogs/\`hostname\`/; chmod -R 777 ${RESULTDIR}/serverlogs/\`hostname\`/"
 
 echo Files after run
 date


### PR DESCRIPTION
DAOS client and server logs are collected after an application completes. If that applciation hangs, is killed, or the script doesn't complete, logs are not collected. In these cases, we need a utility to collect logs.

Let's separate the functionality to collect all logs into a script and replace the code to collect logs in run_client.sh and run_client_resnet.sh with a call to this script.

Signed-off-by: James Nunez <james.nunez@intel.com>