### PR TITLE
endeavour: enable Darshan IO tracing

### DIFF
--- a/edv/test_scripts/client/scripts/run_client.sh
+++ b/edv/test_scripts/client/scripts/run_client.sh
@@ -8,18 +8,11 @@ date
 export I_MPI_OFI_LIBRARY_INTERNAL=0
 export I_MPI_OFI_PROVIDER="verbs;ofi_rxm"
 export I_MPI_DEBUG=4
-
 export SRV_HOSTLIST="${RUNDIR}/../server/hostlists/srv_hostlist${NSERVER}"
 export CLI_HOSTLIST="${RUNDIR}/hostlists/cli_hostlist${NCLIENT}"
-export envIL=""
 export NPROCESS=$(( $NCLIENT * $PPN ))
 export PLABEL="p_${TESTDIR}"
 export CLABEL="c_${TESTDIR}"
-
-#export EXTRA_ENV="-genv DARSHAN_LOGPATH ${RESULTDIR}/darshanlog -genv LD_PRELOAD /panfs/users/rpadma2/apps/darshan-install-impi/lib/libdarshan.so"
-export EXTRA_ENV=""
-
-mkdir -p ${RESULTDIR}/darshanlog
 
 echo NPROCESS=${NPROCESS}
 
@@ -156,13 +149,32 @@ fi
 #  echo "${MOUNTDIR}/vpic" exists
 #fi
 
-if [[ "$IL" == "1" ]]; then
-  #export envIL="-env DARSHAN_LOGPATH=${RESULTDIR}/darshanlog -env LD_PRELOAD=/panfs/users/rpadma2/apps/darshan-install-impi/lib/libdarshan.so:${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so -env D_IL_REPORT=5 -env D_LOG_MASK=ERR"
-  #export envIL="-env LD_PRELOAD=${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so -env D_IL_REPORT=5 -env D_LOG_MASK=ERR"
-  export envIL="-env LD_PRELOAD=${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so -env D_LOG_MASK=ERR"
+LD_PRELOAD_ENV=""
+DARSHAN_ENV=""
+IL_ENV=""
+
+# Set up Darshan
+if [ "$DARSHAN" == "1" ]; then
+        # Path for mpich compiled Darshan
+        DARSHAN_LIB="${RUNDIR}/../apps/${MPI}/darshan/lib/libdarshan.so"
+        export DARSHAN_LOGPATH="${RESULTDIR}/darshanlog"
+        LD_PRELOAD_ENV="-env LD_PRELOAD ${DARSHAN_LIB}"
+        DARSHAN_ENV="-env DARSHAN_LOGPATH ${DARSHAN_LOGPATH}"
+
+        mkdir -p ${DARSHAN_LOGPATH}
 fi
 
-echo
+# Set variables to run with the DAOS Interception Library
+if [[ "$IL" == "1" ]]; then
+        # If we've already set the LD_PRELOAD varaible, append to it
+        if [ -z ${LD_PRELOAD_ENV+x} ]; then
+                LD_PRELOAD_ENV="-env LD_PRELOAD ${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so"
+        else
+                LD_PRELOAD_ENV="${LD_PRELOAD_ENV}:${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so"
+        fi
+
+        IL_ENV="-env D_IL_REPORT=-1 -env D_LOG_MASK=DEBUG -env DD_MASK=\"trace,io\""
+fi
 
 if [[ "${TEST}" =~ "IOR" ]]; then
   #export IORWRITECMD="${RUNDIR}/../apps/ior/install/bin/ior -a DFS -b 150G -C -e -w -W -g -G 27 -k -i 1 -s 1 -o /testFile -O stoneWallingWearOut=1 -O stoneWallingStatusFile=${SWFILEWRITE} -D 60 -d 5 -t 1M --dfs.cont ${CONT} --dfs.group daos_server --dfs.pool ${POOL} --dfs.oclass SX --dfs.chunk_size 1M -v"
@@ -205,17 +217,14 @@ date
 echo
 #I_MPI_DEBUG=4 mpirun -n ${NPROCESS} --hostfile ${CLI_HOSTLIST} -ppn ${PPN} -genv I_MPI_PIN_PROCESSOR_LIST=0-7 ${TESTCMD}
 
-#export DARSHAN_LOGPATH="${RESULTDIR}/darshanlog"
-#export LD_PRELOAD="/panfs/users/rpadma2/apps/darshan-install-impi/lib/libdarshan.so"
-
 echo "which mpiexec"
 which mpiexec
 echo
 
 echo ROMIO_FSTYPE_FORCE=${ROMIO_FSTYPE_FORCE}
-echo "mpiexec -bootstrap ssh ${EXTRA_ENV} ${envIL} -n ${NPROCESS} --hostfile ${CLI_HOSTLIST} -ppn ${PPN} ${TESTCMD}"
+echo "mpiexec -bootstrap ssh ${LD_PRELOAD_ENV} ${DARSHAN_ENV} ${IL_ENV} -n ${NPROCESS} --hostfile ${CLI_HOSTLIST} -ppn ${PPN} ${TESTCMD}"
 echo
-mpiexec -bootstrap ssh ${EXTRA_ENV} ${envIL} -n ${NPROCESS} --hostfile ${CLI_HOSTLIST} -ppn ${PPN} ${TESTCMD}
+mpiexec -bootstrap ssh ${LD_PRELOAD_ENV} ${DARSHAN_ENV} ${IL_ENV} -n ${NPROCESS} --hostfile ${CLI_HOSTLIST} -ppn ${PPN} ${TESTCMD}
 echo
 
 echo Pool query after ${TEST}

--- a/edv/test_scripts/client/testlists/testlist_lammps.sh
+++ b/edv/test_scripts/client/testlists/testlist_lammps.sh
@@ -3,7 +3,7 @@
 helpFunction()
 {
    echo ""
-   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype"
+   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype -d"
    echo -e "\t-s Server List (eg: 2,4,8,16,32)"
    echo -e "\t-c Total clients to use"
    echo -e "\t-p Number of processors per node (default=64)"
@@ -12,10 +12,11 @@ helpFunction()
    echo -e "\t-r DAOS Redundancy Factor(eg: rf=0,1,..)"
    echo -e "\t-i DAOS Interception library(eg: il=0,1)"
    echo -e "\t-t DAOS MPI Type(eg: mptype=fpp, mpiio, mpiiodfs)"
+   echo -e "\t-d Trace application IO with Darshan [default=off]"
    exit 1 # Exit script after printing help
 }
 
-while getopts s:c:p:m:b:r:i:t: opt
+while getopts s:c:p:m:b:r:i:t:d opt
 do
    case ${opt} in
       s) server_list="$OPTARG" ;;
@@ -26,6 +27,7 @@ do
       r) rf="$OPTARG" ;;
       i) il="$OPTARG" ;;
       t) mptype="$OPTARG" ;;
+      d) darshan="1" ;;
       ?) helpFunction ;; # Print helpFunction in case parameter is non-existent
    esac
 done
@@ -38,6 +40,7 @@ done
 [ -z $rf ] && echo "DAOS Redundancy Argument Missing (eg: rf=0,1,..)" && exit 1
 [ -z $il ] && echo "Intersection Library Argument Missing (eg: il=0,1)" && exit 1
 [ -z $mptype ] && echo "MPI Type Argument Missing (eg: mptype=fpp,mpiio,mpiiodfs)" && exit 1
+[ -z $darshan ] && darshan="0"
 
 export SCM="700G" #700G
 export NVME="30T" #1T
@@ -55,6 +58,7 @@ export APPRUNDIR="${APPSRC}"
 export OUTDIR="${MOUNTDIR}/${APPNAME}"
 
 export PPN=${ppn}
+export DARSHAN=${darshan}
 export MOUNT_DFUSE=1
 
 cd $RUNDIR

--- a/edv/test_scripts/client/testlists/testlist_resnet.sh
+++ b/edv/test_scripts/client/testlists/testlist_resnet.sh
@@ -4,7 +4,7 @@
 helpFunction()
 {
    echo ""
-   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype"
+   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype -d"
    echo -e "\t-s Server List (eg: 2,4,8,16,32) "
    echo -e "\t-c Total clients to use"
    echo -e "\t-p Number of processors per node (default=64)"
@@ -13,10 +13,11 @@ helpFunction()
    echo -e "\t-r DAOS Redundancy Factor(eg: rf=0,1,..) "
    echo -e "\t-i DAOS Interception library(eg: il=0,1) "
    echo -e "\t-t DAOS MPI Type (eg: mptype=fpp, mpiio, mpiiodfs) "
+   echo -e "\t-d Trace application IO with Darshan [default=off]"
    exit 1 # Exit script after printing help
 }
 
-while getopts s:c:p:m:b:i:r:t: opt
+while getopts s:c:p:m:b:i:r:t:d opt
 do
    case ${opt} in
       s) server_list="$OPTARG" ;;
@@ -27,6 +28,7 @@ do
       r) rf="$OPTARG" ;;
       i) il="$OPTARG" ;;
       t) mptype="$OPTARG" ;;
+      d) darshan="1" ;;
       ?) helpFunction ;; # Print helpFunction in case parameter is non-existent
    esac
 done
@@ -39,7 +41,7 @@ done
 [ -z $rf ] && echo "DAOS Redundancy Argument Missing (eg: rf=0,1,..)" && exit 1
 [ -z $il ] && echo "Intersection Library Argument Missing (eg: il=0,1)" && exit 1
 [ -z $mptype ] && echo "MPI Type Argument Missing (eg: mptype=fpp,mpiio,mpiiodfs" && exit 1
-
+[ -z $darshan ] && darshan="0"
 
 export SCM="700G" #700G
 export NVME="30T" #1T
@@ -57,6 +59,7 @@ export APPRUNDIR="${APPSRC}"
 export OUTDIR="${MOUNTDIR}/${APPNAME}"
 
 export PPN=${ppn}
+export DARSHAN=${darshan}
 export MOUNT_DFUSE=1
 
 cd $RUNDIR

--- a/edv/test_scripts/client/testlists/testlist_vpic.sh
+++ b/edv/test_scripts/client/testlists/testlist_vpic.sh
@@ -3,7 +3,7 @@
 helpFunction()
 {
    echo ""
-   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype"
+   echo "Usage: $0 -s server_list -c clients -p ppn -m mpi -b tb -r rf -i il -t mptype -d"
    echo -e "\t-s Server List (eg: 2,4,8,16,32)"
    echo -e "\t-c Total clients to use"
    echo -e "\t-p Number of processors per node (default=64)"
@@ -12,10 +12,11 @@ helpFunction()
    echo -e "\t-r DAOS Redundancy Factor(eg: rf=0,1,..)"
    echo -e "\t-i DAOS Interception library(eg: il=0,1)"
    echo -e "\t-t DAOS MPI Type(eg: mptype=fpp, mpiio, mpiiodfs)"
+   echo -e "\t-d Trace application IO with Darshan [default=off]"
    exit 1 # Exit script after printing help
 }
 
-while getopts s:c:p:m:b:r:i:t: opt
+while getopts s:c:p:m:b:r:i:t:d opt
 do
    case ${opt} in
       s) server_list="$OPTARG" ;;
@@ -26,6 +27,7 @@ do
       r) rf="$OPTARG" ;;
       i) il="$OPTARG" ;;
       t) mptype="$OPTARG" ;;
+      d) darshan="1" ;;
       ?) helpFunction ;; # Print helpFunction in case parameter is non-existent
    esac
 done
@@ -38,6 +40,7 @@ done
 [ -z $rf ] && echo "DAOS Redundancy Argument Missing (eg: rf=0,1,..)" && exit 1
 [ -z $il ] && echo "Intersection Library Argument Missing (eg: il=0,1)" && exit 1
 [ -z $mptype ] && echo "MPI Type Argument Missing (eg: mptype=fpp,mpiio,mpiiodfs" && exit 1
+[ -z $darshan ] && darshan="0"
 
 export SCM="700G" #700G
 export NVME="30T" #1T
@@ -57,6 +60,7 @@ export OUTDIR="${MOUNTDIR}/${APPNAME}"
 export TESTCMD="${APPSRC}/harris.xl.daos.one_loop.Linux"
 
 export PPN=${ppn}
+export DARSHAN=${darshan}
 export MOUNT_DFUSE=1
 
 cd $RUNDIR


### PR DESCRIPTION
Darshan is an IO profiling tool. We’ve enabled Darshan for all applications run with the Endeavour test scripts using the “-d” flag on the testlist_* command line.

There are some limitations with this implementation:
- the Darshan library must be installed in ${CLIENT}./apps/${MPI}/darshan/lib/libdarshan.so
- the Darshan log will be created in the directory ${RESULTDIR}/darshanlog

Signed-off-by: James Nunez <james.nunez@intel.com>