### PR TITLE
endeavour: Modify Darshan Fix and IL Setting

### DIFF
--- a/edv/test_scripts/client/scripts/run_client.sh
+++ b/edv/test_scripts/client/scripts/run_client.sh
@@ -167,13 +167,13 @@ fi
 # Set variables to run with the DAOS Interception Library
 if [[ "$IL" == "1" ]]; then
         # If we've already set the LD_PRELOAD varaible, append to it
-        if [ -z ${LD_PRELOAD_ENV+x} ]; then
+        if [ -z ${LD_PRELOAD_ENV:+x} ]; then
                 LD_PRELOAD_ENV="-env LD_PRELOAD ${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so"
         else
                 LD_PRELOAD_ENV="${LD_PRELOAD_ENV}:${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so"
         fi
 
-        IL_ENV="-env D_IL_REPORT=-1 -env D_LOG_MASK=DEBUG -env DD_MASK=\"trace,io\""
+        IL_ENV="-env D_IL_REPORT=5 -env D_LOG_MASK=DEBUG -env DD_MASK=\"trace,io\""
 fi
 
 if [[ "${TEST}" =~ "IOR" ]]; then


### PR DESCRIPTION
We have enabled running Darshan on Endeavour. We to fix the detection of when the LD_PRELOAD variable is set.

We also need to reduce the default amount of output written when the Interception Library is used.

Signed-off-by: James Nunez <james.nunez@intel.com>