### PR TITLE
frontera: parse timestamp command-line

### DIFF
--- a/frontera/run_build.sh
+++ b/frontera/run_build.sh
@@ -72,6 +72,8 @@ while [ $# -gt 0 ]; do
       ;;
     --build-dir*|-d*) if [[ "$1" != *=* ]]; then shift; fi
       BUILD_DIR="${1#*=}";;
+    --timestamp*) if [[ "$1" != *=* ]]; then shift; fi
+      TIMESTAMP="${1#*=}";;
     --daos-branch*|-b*) if [[ "$1" != *=* ]]; then shift; fi
       DAOS_BRANCH="${1#*=}";;
     --daos-commit*) if [[ "$1" != *=* ]]; then shift; fi


### PR DESCRIPTION
The run_build script help lists "--timestamp" as a valid command-line option to set the time stamp for the build and dictate the path to install DAOS. We get an error if we try to use the --timestamp option.