### PR TITLE
endeavour: allow use of pil4dfs IL

### DIFF
--- a/edv/test_scripts/client/scripts/run_client.sh
+++ b/edv/test_scripts/client/scripts/run_client.sh
@@ -165,12 +165,12 @@ if [ "$DARSHAN" == "1" ]; then
 fi
 
 # Set variables to run with the DAOS Interception Library
-if [[ "$IL" == "1" ]]; then
-        # If we've already set the LD_PRELOAD varaible, append to it
+if [[ ! -z "$IL" ]]; then
+        # If we've already set the LD_PRELOAD variable, append to it
         if [ -z ${LD_PRELOAD_ENV:+x} ]; then
-                LD_PRELOAD_ENV="-env LD_PRELOAD ${BUILDDIR}/${TB}/CLIENT/install/lib64/libioil.so"
+                LD_PRELOAD_ENV="-env LD_PRELOAD ${DAOS_INSTALL}/lib64/lib${IL}.so"
         else
-                LD_PRELOAD_ENV="${LD_PRELOAD_ENV}:${DAOS_INSTALL}/lib64/libioil.so"
+                LD_PRELOAD_ENV="${LD_PRELOAD_ENV}:${DAOS_INSTALL}/lib64/lib${IL}.so"
         fi
 
         IL_ENV="-env D_IL_REPORT=5 -env D_LOG_MASK=DEBUG -env DD_MASK=\"trace,io\""

--- a/edv/test_scripts/client/testlists/testlist_common.sh
+++ b/edv/test_scripts/client/testlists/testlist_common.sh
@@ -12,7 +12,7 @@ helpFunction()
    echo -e "\t-m Type of MPI to use (MPI, IMPI)"
    echo -e "\t-b DAOS Test Build to use (eg: daos_xxx)"
    echo -e "\t-r DAOS Redundancy Factor(eg: rf=0,1,..)"
-   echo -e "\t-i DAOS Interception library(eg: il=0,1)"
+   echo -e "\t-i DAOS Interception library (eg: 'ioil' or 'pil4dfs')"
    echo -e "\t-e DAOS container property: cell size in bytes (eg: 1048576 for 1MB)"
    echo -e "\t-k DAOS container property: chunk size (eg: 4MB)"
    echo -e "\t-o DAOS container property: object class (oclass) (eg EC_4P2GX, EC_8P2GX)"
@@ -20,6 +20,17 @@ helpFunction()
    echo -e "\t-z Setup DAOS servers and clients (start_server, start_client), run application (app), or clean up (stop_client, stop_server)"
 
    exit 1 # Exit script after printing help
+}
+
+function check_il(){
+  local il=$1
+
+  [ -z $il ] && return 0
+
+  if [ "$il" != "ioil" ] && [ "$il" != "pil4dfs" ]; then
+          echo "Unknown Interception Library entered '$il'. Valid 'ioil' or 'pil4dfs'"
+          return 1
+  fi
 }
 
 # Parse and set all common application environment variables
@@ -32,6 +43,7 @@ parseAndSetParameters()
   CHUNK_SIZE=''
   OCLASS=''
   RUNTYPE="all"
+  IL=''
 
   # Parse the command line
   while getopts ds:c:p:m:b:i:r:t:e:k:o:z: opt
@@ -60,8 +72,11 @@ parseAndSetParameters()
   [ -z $MPI ] && echo "MPI Argument Missing (MPI or IMPI)" && exit 1
   [ -z $TB ] && echo "Test Build Argument Missing (eg: daos_xxx)" && exit 1
   [ -z $RF ] && echo "DAOS Redundancy Argument Missing (eg: rf=0,1,..)" && exit 1
-  [ -z $IL ] && echo "Intersection Library Argument Missing (eg: il=0,1)" && exit 1
   [ -z $mptype ] && echo "MPI Type Argument Missing (eg: mptype=fpp,mpiio,mpiiodfs)" && exit 1
+
+  # Check values of input varibles
+  check_il $IL || return 1
+
 
   # Export all variables. Individual scripts can over ride these varaibles
   export IL=$IL

--- a/edv/test_scripts/client/testlists/testlist_efispec.sh
+++ b/edv/test_scripts/client/testlists/testlist_efispec.sh
@@ -7,7 +7,7 @@ source ${RUNDIR}/testlists/testlist_common.sh
 source ${RUNDIR}/scripts/client_env.sh
 
 # Parse the command line
-parseAndSetParameters $@
+parseAndSetParameters $@ || exit
 
 export SCM="700G" #700G
 export NVME="30T" #1T

--- a/edv/test_scripts/client/testlists/testlist_lammps.sh
+++ b/edv/test_scripts/client/testlists/testlist_lammps.sh
@@ -7,7 +7,7 @@ source ${RUNDIR}/testlists/testlist_common.sh
 source ${RUNDIR}/scripts/client_env.sh
 
 # Parse the command line
-parseAndSetParameters $@
+parseAndSetParameters $@ || exit
 
 export SCM="700G" #700G
 export NVME="30T" #1T
@@ -34,7 +34,7 @@ export TESTCMD="${APPSRC}/src/lmp_mpi -i ${APPINFILE}"
 
 if [[ "$TYPE" =~ "mpiiodfs" ]]; then
   export DFUSECACHE="--enable-caching" #FOR DFS
-  export IL=0 #FOR DFS
+  export IL='' #FOR DFS
   export ROMIO_FSTYPE_FORCE="daos:" #FOR DFS
 else
   export DFUSECACHE="--disable-caching"

--- a/edv/test_scripts/client/testlists/testlist_vpic.sh
+++ b/edv/test_scripts/client/testlists/testlist_vpic.sh
@@ -7,7 +7,7 @@ source ${RUNDIR}/testlists/testlist_common.sh
 source ${RUNDIR}/scripts/client_env.sh
 
 # Parse the command line
-parseAndSetParameters $@
+parseAndSetParameters $@ || exit
 
 export SCM="700G" #700G
 export NVME="30T" #1T


### PR DESCRIPTION
The Endeavour scripts currently only use the ioil Interception Library. We need to allow for use of pil4dfs Interception Library.

The ‘-i’ command-line option will be redefined from the binary meaning of use the interception library (1) or don’t use the library (0) to specifying which interception library to use; ‘ioil’ or ‘pil4dfs’.