### PR TITLE
frontera: build pciutils

### DIFF
--- a/frontera/run_build.sh
+++ b/frontera/run_build.sh
@@ -260,6 +260,12 @@ function install_daos_deps() {
         "${CURRENT_DIR}/utils/build_install_capstone" "${WORK}/daos_deps" || return
         "${CURRENT_DIR}/utils/check_for_lib" "capstone" || return
     fi
+    "${CURRENT_DIR}/utils/check_for_lib" "pci"
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        "${CURRENT_DIR}/utils/build_install_pciutils" "${WORK}/daos_deps" || return
+        "${CURRENT_DIR}/utils/check_for_lib" "pci" || return
+    fi
 }
 
 # Setup a new build directory, removing if it already exists

--- a/frontera/utils/build_install_pciutils
+++ b/frontera/utils/build_install_pciutils
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Build and install pciutils from scratch
+#
+# Source: https://github.com/pciutils/pciutils/blob/1bfc2be0ce96f05536764d6ac230d596aefd8dfa/README
+#
+
+function usage() {
+    echo "Usage: $(basename $0) <install_dir>"
+}
+
+function _install_here() {
+    local install_dir="$1"
+
+    wget https://github.com/pciutils/pciutils/releases/download/v3.13.0/pciutils-3.13.0.tar.gz || return
+    tar -xvzf pciutils-3.13.0.tar.gz || return
+    pushd pciutils-3.13.0
+        mkdir -p "$install_dir" || return
+        make ZLIB="no" CFLAGS="-fPIE -O2 -std=gnu99" PREFIX="$install_dir" install-lib || return
+    popd
+}
+
+function install() {
+    local install_dir="$1"
+    local rc=0
+
+    echo "Installing pciutils in $install_dir"
+    tmp_dir="$(mktemp -d 2>/dev/null)"
+    pushd "$tmp_dir"
+        _install_here "$install_dir"
+        rc=$?
+    popd
+    rm -r "$tmp_dir"
+    if [ $rc == 0 ]; then
+        echo "Success!"
+    fi
+    exit $rc
+}
+
+if [ -z "$1" ]; then
+    usage
+    exit 1
+fi
+
+install "$1"


### PR DESCRIPTION
A PR landed to the DAOS master (PR #14395) and DAOS release/2.6 (PR #14845) branches that requires the pciutils package.  Add detection and installation of pciutils to the frontera build process.