### PR TITLE
frontera: avoid statx calls

### DIFF
--- a/frontera/patches/daos_scons_dfuse.patch.732997994d8ba560b674fe1e80b9677fcec049a3
+++ b/frontera/patches/daos_scons_dfuse.patch.732997994d8ba560b674fe1e80b9677fcec049a3
@@ -1,0 +1,15 @@
+diff --git a/src/tests/suite/SConscript b/src/tests/suite/SConscript
+index a118227fa..150f8115c 100644
+--- a/src/tests/suite/SConscript
++++ b/src/tests/suite/SConscript
+@@ -10,8 +10,8 @@ def scons():
+
+     dfuse_env = base_env.Clone()
+     dfuse_env.compiler_setup()
+-    dfusetest = dfuse_env.d_program(File("dfuse_test.c"), LIBS='cmocka')
+-    denv.Install('$PREFIX/bin/', dfusetest)
++#    dfusetest = dfuse_env.d_program(File("dfuse_test.c"), LIBS='cmocka')
++#    denv.Install('$PREFIX/bin/', dfusetest)
+
+     denv.AppendUnique(LIBPATH=[Dir('../../client/dfs')])
+     denv.AppendUnique(CPPPATH=[Dir('../../client/dfs').srcnode()])

--- a/frontera/run_build.sh
+++ b/frontera/run_build.sh
@@ -356,6 +356,11 @@ function build_daos() {
         fi
     fi
 
+    # avoid statx calls in dfuse tests
+    if [ $(git_has_commit "732997994d8ba560b674fe1e80b9677fcec049a3") = true ]; then
+            copy_and_apply_patch  daos_scons_dfuse.patch.732997994d8ba560b674fe1e80b9677fcec049a3 |& tee -a ${BUILD_DIR}/${TIMESTAMP}/repo_info.txt
+    fi
+
     scons MPI_PKG=any \
           --build-deps=${SCONS_BUILD_DEPS} \
           --config=force \


### PR DESCRIPTION
Frontera is running CentOS7 with kernel 3.10 which means statx struct is not defined in sys/stat.h and does not contain linux/stat.h. Since the dfuse test calls statx, don't build the dfuse test.